### PR TITLE
deleted dispose() call on _controller from VlcPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+* Deleted dispose calls on VlcPlayerController from VlcPlayer
+
 ## 4.0.2
 * Update Cocoapods version for VLCkit on iOS. This fixes issues with iOS 12 and Simulators. Credits to Mitch Ross (https://github.com/mitchross).
 

--- a/lib/flutter_vlc_player.dart
+++ b/lib/flutter_vlc_player.dart
@@ -187,15 +187,8 @@ class _VlcPlayerState extends State<VlcPlayer>
 
   @override
   void deactivate() {
-    _controller.dispose();
     playerInitialized = false;
     super.deactivate();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_vlc_player
 description: A VLC-powered alternative to Flutter's video_player. Supports multiple players on one screen.
-version: 4.0.2
+version: 4.0.3
 homepage: https://github.com/solid-software/flutter_vlc_player
 
 environment:


### PR DESCRIPTION
Deleted dispose() calls from VlcPlayer on VlcPlayerController _controller variable because dispose() should be called only in the object where instance of VlcPlayerController was created.