### PR TITLE
Set default arguments

### DIFF
--- a/ios/Classes/SwiftFlutterVlcPlayerPlugin.swift
+++ b/ios/Classes/SwiftFlutterVlcPlayerPlugin.swift
@@ -62,7 +62,7 @@ public class VLCView: NSObject, FlutterPlatformView {
             
             guard let self = self else { return }
             
-            if let arguments = call.arguments as? [String: Any] {
+            if let arguments = (call.arguments ?? [:]) as? [String: Any] {
                 
                 switch FlutterMethodCallOption(rawValue: call.method) {
                 case .initialize:


### PR DESCRIPTION
Fixes no method errors on methods that do not have arguments

Closes #106
Closes #124

Some methods (such as `dispose` and most getters like  `getTime` and `getDuration`) do not pass in arguments:

```dart
  /// Returns current media seek time in milliseconds.
  Future<int> getTime() async {
    var result = await _methodChannel.invokeMethod("getTime");
    return result;
  }
```

Which means that the main FlutterMethodCall switch case never hits. This sets a default empty dictionary if no arguments exist allowing the calls to fall through as expected.