### PR TITLE
Fix memory leak issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,11 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   @override
-  void dispose() {
-    _videoPlayerController.stopRendererScanning();
-    _videoPlayerController.removeListener(() {});
+  void dispose() async {
     super.dispose();
+    _videoPlayerController.removeListener(() {});
+    await _videoPlayerController.stopRendererScanning();
+    await _videoViewController.dispose();
   }
 
   @override

--- a/flutter_vlc_player/README.md
+++ b/flutter_vlc_player/README.md
@@ -123,10 +123,11 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   @override
-  void dispose() {
-    _videoPlayerController.stopRendererScanning();
-    _videoPlayerController.removeListener(() {});
+  void dispose() async {
     super.dispose();
+    _videoPlayerController.removeListener(() {});
+    await _videoPlayerController.stopRendererScanning();
+    await _videoViewController.dispose();
   }
 
   @override

--- a/flutter_vlc_player/README.md
+++ b/flutter_vlc_player/README.md
@@ -125,7 +125,6 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void dispose() async {
     super.dispose();
-    _videoPlayerController.removeListener(() {});
     await _videoPlayerController.stopRendererScanning();
     await _videoViewController.dispose();
   }

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
@@ -59,6 +59,20 @@ final class FlutterVlcPlayer implements PlatformView {
         return textureView;
     }
 
+    @Override
+    public void dispose() {
+        textureEntry.release();
+        mediaEventChannel.setStreamHandler(null);
+        rendererEventChannel.setStreamHandler(null);
+        if (mediaPlayer != null) {
+            mediaPlayer.stop();
+            mediaPlayer.getVLCVout().detachViews();
+            mediaPlayer.release();
+        }
+        if (libVLC != null)
+            libVLC.release();
+    }
+
     // VLC Player
     FlutterVlcPlayer(int viewId, Context context, BinaryMessenger binaryMessenger, TextureRegistry textureRegistry) {
         this.context = context;
@@ -594,19 +608,6 @@ final class FlutterVlcPlayer implements PlatformView {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
         return Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT);
-    }
-
-    public void dispose() {
-        textureEntry.release();
-        mediaEventChannel.setStreamHandler(null);
-        rendererEventChannel.setStreamHandler(null);
-        if (mediaPlayer != null) {
-            mediaPlayer.stop();
-            mediaPlayer.getVLCVout().detachViews();
-            mediaPlayer.release();
-        }
-        if (libVLC != null)
-            libVLC.release();
     }
 
     private void log(String message) {

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
@@ -52,6 +52,7 @@ final class FlutterVlcPlayer implements PlatformView {
     private MediaPlayer mediaPlayer;
     private List<RendererDiscoverer> rendererDiscoverers;
     private List<RendererItem> rendererItems;
+    private boolean isDisposed = false;
 
     // Platform view
     @Override
@@ -61,6 +62,9 @@ final class FlutterVlcPlayer implements PlatformView {
 
     @Override
     public void dispose() {
+        if (isDisposed)
+            return;
+        //
         textureEntry.release();
         mediaEventChannel.setStreamHandler(null);
         rendererEventChannel.setStreamHandler(null);
@@ -68,9 +72,13 @@ final class FlutterVlcPlayer implements PlatformView {
             mediaPlayer.stop();
             mediaPlayer.getVLCVout().detachViews();
             mediaPlayer.release();
+            mediaPlayer = null;
         }
-        if (libVLC != null)
+        if (libVLC != null) {
             libVLC.release();
+            libVLC = null;
+        }
+        isDisposed = true;
     }
 
     // VLC Player
@@ -550,10 +558,12 @@ final class FlutterVlcPlayer implements PlatformView {
     }
 
     void stopRendererScanning() {
+        if (isDisposed)
+            return;
+        //
         for (RendererDiscoverer rendererDiscoverer : rendererDiscoverers) {
             rendererDiscoverer.stop();
             rendererDiscoverer.setEventListener(null);
-
         }
         rendererDiscoverers.clear();
         rendererItems.clear();
@@ -585,6 +595,9 @@ final class FlutterVlcPlayer implements PlatformView {
     }
 
     void castToRenderer(String rendererDevice) {
+        if(isDisposed)
+            return;
+        //
         boolean isPlaying = mediaPlayer.isPlaying();
         if (isPlaying)
             mediaPlayer.pause();

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerBuilder.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerBuilder.java
@@ -82,8 +82,7 @@ public class FlutterVlcPlayerBuilder implements Messages.VlcPlayerApi {
 
     @Override
     public void dispose(Messages.TextureMessage arg) {
-        FlutterVlcPlayer player = vlcPlayers.get(arg.getTextureId());
-        player.dispose();
+        // the player has been already disposed by platform we just remove it from players list
         vlcPlayers.remove(arg.getTextureId());
     }
 

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
@@ -22,6 +22,7 @@ public class FlutterVlcPlayerPlugin implements FlutterPlugin, ActivityAware {
     public FlutterVlcPlayerPlugin() {
     }
 
+    @SuppressWarnings("deprecation")
     public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
         flutterVlcPlayerFactory =
                 new FlutterVlcPlayerFactory(

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
@@ -9,8 +9,6 @@ import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.view.FlutterNativeView;
 
 public class FlutterVlcPlayerPlugin implements FlutterPlugin, ActivityAware {
 
@@ -37,12 +35,9 @@ public class FlutterVlcPlayerPlugin implements FlutterPlugin, ActivityAware {
                         VIEW_TYPE,
                         flutterVlcPlayerFactory
                 );
-        registrar.addViewDestroyListener(new PluginRegistry.ViewDestroyListener() {
-            @Override
-            public boolean onViewDestroy(FlutterNativeView view) {
-                stopListening();
-                return false;
-            }
+        registrar.addViewDestroyListener(view -> {
+            stopListening();
+            return false;
         });
         //
         startListening();

--- a/flutter_vlc_player/example/ios/Flutter/Debug.xcconfig
+++ b/flutter_vlc_player/example/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/flutter_vlc_player/example/ios/Flutter/Release.xcconfig
+++ b/flutter_vlc_player/example/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/flutter_vlc_player/example/lib/multiple_tab.dart
+++ b/flutter_vlc_player/example/lib/multiple_tab.dart
@@ -64,11 +64,12 @@ class _MultipleTabState extends State<MultipleTab> {
   }
 
   @override
-  void dispose() {
-    for (var i = 0; i < controllers.length; i++) {
-      controllers[i].stopRendererScanning();
-      controllers[i].removeListener(() {});
-    }
+  void dispose() async {
     super.dispose();
+    for (var i = 0; i < controllers.length; i++) {
+      controllers[i].removeListener(() {});
+      await controllers[i].stopRendererScanning();
+      await controllers[i].dispose();
+    }
   }
 }

--- a/flutter_vlc_player/example/lib/multiple_tab.dart
+++ b/flutter_vlc_player/example/lib/multiple_tab.dart
@@ -66,10 +66,9 @@ class _MultipleTabState extends State<MultipleTab> {
   @override
   void dispose() async {
     super.dispose();
-    for (var i = 0; i < controllers.length; i++) {
-      controllers[i].removeListener(() {});
-      await controllers[i].stopRendererScanning();
-      await controllers[i].dispose();
+    for (final controller in controllers) {
+      await controller.stopRendererScanning();
+      await controller.dispose();
     }
   }
 }

--- a/flutter_vlc_player/example/lib/single_tab.dart
+++ b/flutter_vlc_player/example/lib/single_tab.dart
@@ -18,6 +18,7 @@ class SingleTab extends StatefulWidget {
 class _SingleTabState extends State<SingleTab> {
   VlcPlayerController _controller;
   final _key = GlobalKey<VlcPlayerWithControlsState>();
+
   //
   List<VideoData> listVideos;
   int selectedVideoIndex;
@@ -221,9 +222,10 @@ class _SingleTabState extends State<SingleTab> {
   }
 
   @override
-  void dispose() {
-    _controller.stopRendererScanning();
-    _controller.removeListener(() {});
+  void dispose() async {
     super.dispose();
+    _controller.removeListener(() {});
+    await _controller.stopRendererScanning();
+    await _controller.dispose();
   }
 }

--- a/flutter_vlc_player/example/lib/single_tab.dart
+++ b/flutter_vlc_player/example/lib/single_tab.dart
@@ -181,7 +181,7 @@ class _SingleTabState extends State<SingleTab> {
                         hwAcc: HwAcc.FULL);
                     break;
                   case VideoType.file:
-                    Scaffold.of(context).showSnackBar(
+                    ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
                         content: Text('Copying file to temporary storage...'),
                       ),
@@ -189,7 +189,7 @@ class _SingleTabState extends State<SingleTab> {
                     await Future.delayed(Duration(seconds: 1));
                     var tempVideo = await _loadVideoToFs();
                     await Future.delayed(Duration(seconds: 1));
-                    Scaffold.of(context).showSnackBar(
+                    ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
                         content: Text('Now trying to play...'),
                       ),
@@ -198,7 +198,7 @@ class _SingleTabState extends State<SingleTab> {
                     if (await tempVideo.exists()) {
                       await _controller.setMediaFromFile(tempVideo);
                     } else {
-                      Scaffold.of(context).showSnackBar(
+                      ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
                           content: Text('File load error.'),
                         ),

--- a/flutter_vlc_player/example/lib/single_tab.dart
+++ b/flutter_vlc_player/example/lib/single_tab.dart
@@ -182,7 +182,7 @@ class _SingleTabState extends State<SingleTab> {
                         hwAcc: HwAcc.FULL);
                     break;
                   case VideoType.file:
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    Scaffold.of(context).showSnackBar(
                       SnackBar(
                         content: Text('Copying file to temporary storage...'),
                       ),
@@ -190,7 +190,7 @@ class _SingleTabState extends State<SingleTab> {
                     await Future.delayed(Duration(seconds: 1));
                     var tempVideo = await _loadVideoToFs();
                     await Future.delayed(Duration(seconds: 1));
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    Scaffold.of(context).showSnackBar(
                       SnackBar(
                         content: Text('Now trying to play...'),
                       ),
@@ -199,7 +199,7 @@ class _SingleTabState extends State<SingleTab> {
                     if (await tempVideo.exists()) {
                       await _controller.setMediaFromFile(tempVideo);
                     } else {
-                      ScaffoldMessenger.of(context).showSnackBar(
+                      Scaffold.of(context).showSnackBar(
                         SnackBar(
                           content: Text('File load error.'),
                         ),
@@ -224,7 +224,6 @@ class _SingleTabState extends State<SingleTab> {
   @override
   void dispose() async {
     super.dispose();
-    _controller.removeListener(() {});
     await _controller.stopRendererScanning();
     await _controller.dispose();
   }

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -503,7 +503,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
       );
       await _controller.castToRenderer(selectedCastDeviceName);
     } else {
-      Scaffold.of(context)
+      ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text('No Display Device Found!')));
     }
   }

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -503,7 +503,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
       );
       await _controller.castToRenderer(selectedCastDeviceName);
     } else {
-      ScaffoldMessenger.of(context)
+      Scaffold.of(context)
           .showSnackBar(SnackBar(content: Text('No Display Device Found!')));
     }
   }

--- a/flutter_vlc_player/lib/src/vlc_player_controller.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_controller.dart
@@ -128,12 +128,14 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   bool _isDisposed = false;
   Completer<void> _creatingCompleter;
-  StreamSubscription<dynamic> _mediaEventSubscription;
-  StreamSubscription<dynamic> _rendererEventSubscription;
   VlcAppLifeCycleObserver _lifeCycleObserver;
 
   /// Attempts to open the given [url] and load metadata about the video.
   Future<void> initialize() async {
+    if (_isDisposed) {
+      throw Exception(
+          'initialize was called on a disposed VlcPlayerController');
+    }
     if (value.isInitialized) {
       throw Exception('Already Initialized');
     }
@@ -257,7 +259,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
       }
     }
 
-    _mediaEventSubscription = vlcPlayerPlatform
+    vlcPlayerPlatform
         .mediaEventsFor(_viewId)
         .listen(mediaEventListener, onError: errorListener);
 
@@ -284,9 +286,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
       }
     }
 
-    _rendererEventSubscription = vlcPlayerPlatform
-        .rendererEventsFor(_viewId)
-        .listen(rendererEventListener);
+    vlcPlayerPlatform.rendererEventsFor(_viewId).listen(rendererEventListener);
 
     if (!initializingCompleter.isCompleted) {
       initializingCompleter.complete(null);
@@ -304,18 +304,17 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   @override
   Future<void> dispose() async {
-    if (_creatingCompleter != null) {
-      await _creatingCompleter.future;
-      if (!_isDisposed) {
-        _isDisposed = true;
-        await _mediaEventSubscription?.cancel();
-        await _rendererEventSubscription?.cancel();
-        await vlcPlayerPlatform.dispose(_viewId);
-      }
-      _lifeCycleObserver?.dispose();
+    if (_isDisposed) {
+      return;
     }
+    _lifeCycleObserver?.dispose();
     _isDisposed = true;
     super.dispose();
+    //
+    if (_creatingCompleter != null) {
+      await _creatingCompleter.future;
+      await vlcPlayerPlatform.dispose(_viewId);
+    }
   }
 
   /// This stops playback and changes the data source. Once the new data source has been loaded, the playback state will revert to
@@ -392,9 +391,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     bool autoPlay,
     HwAcc hwAcc,
   }) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setStreamUrl');
     await vlcPlayerPlatform.stop(_viewId);
     await vlcPlayerPlatform.setStreamUrl(
       _viewId,
@@ -413,9 +410,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// has been sent to the platform, not when playback itself is totally
   /// finished.
   Future<void> play() async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('play');
     await vlcPlayerPlatform.play(_viewId);
     // This ensures that the correct playback speed is always applied when
     // playing back. This is necessary because we do not set playback speed
@@ -425,31 +420,26 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   /// Pauses the video.
   Future<void> pause() async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('pause');
     await vlcPlayerPlatform.pause(_viewId);
   }
 
   /// stops the video.
   Future<void> stop() async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('stop');
     await vlcPlayerPlatform.stop(_viewId);
   }
 
   /// Sets whether or not the video should loop after playing once.
   Future<void> setLooping(bool looping) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setLooping');
     value = value.copyWith(isLooping: looping);
     await vlcPlayerPlatform.setLooping(_viewId, looping);
   }
 
   /// Returns true if media is playing.
   Future<bool> isPlaying() async {
+    _throwIfNotInitialized('isPlaying');
     return await vlcPlayerPlatform.isPlaying(_viewId);
   }
 
@@ -464,9 +454,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// If [moment] is outside of the video's full range it will be automatically
   /// and silently clamped.
   Future<void> seekTo(Duration position) async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('seekTo');
     if (position > value.duration) {
       position = value.duration;
     } else if (position < Duration.zero) {
@@ -483,9 +471,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   /// Returns the position in the current video.
   Future<Duration> getPosition() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getPosition');
     var position = await vlcPlayerPlatform.getPosition(_viewId);
     value = value.copyWith(position: position);
     return position;
@@ -496,18 +482,14 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// [volume] indicates a value between 0 (silent) and 100 (full volume) on a
   /// linear scale.
   Future<void> setVolume(int volume) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setVolume');
     value = value.copyWith(volume: volume.clamp(0, 100));
     await vlcPlayerPlatform.setVolume(_viewId, value.volume);
   }
 
   /// Returns current vlc volume level.
   Future<int> getVolume() async {
-    if (!value.isInitialized || _isDisposed) {
-      return value.volume;
-    }
+    _throwIfNotInitialized('getVolume');
     var volume = await vlcPlayerPlatform.getVolume(_viewId);
     value = value.copyWith(volume: volume.clamp(0, 100));
     return volume;
@@ -515,9 +497,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   /// Returns duration/length of loaded video
   Future<Duration> getDuration() async {
-    if (!value.isInitialized || _isDisposed) {
-      return Duration.zero;
-    }
+    _throwIfNotInitialized('getDuration');
     var duration = await vlcPlayerPlatform.getDuration(_viewId);
     value = value.copyWith(duration: duration);
     return duration;
@@ -542,11 +522,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
         'Zero playback speed is not supported. Consider using [pause].',
       );
     }
-    value = value.copyWith(playbackSpeed: speed);
-    //
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setPlaybackSpeed');
     // Setting the playback speed on iOS will trigger the video to play. We
     // prevent this from happening by not applying the playback speed until
     // the video is manually played from Flutter.
@@ -559,10 +535,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   /// Returns the vlc playback speed.
   Future<double> getPlaybackSpeed() async {
-    if (!value.isInitialized || _isDisposed) {
-      return value.playbackSpeed;
-    }
-    //
+    _throwIfNotInitialized('getPlaybackSpeed');
     var speed = await vlcPlayerPlatform.getPlaybackSpeed(_viewId);
     value = value.copyWith(playbackSpeed: speed);
     return speed;
@@ -570,9 +543,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   /// Return the number of subtitle tracks (both embedded and inserted)
   Future<int> getSpuTracksCount() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getSpuTracksCount');
     var spuTracksCount = await vlcPlayerPlatform.getSpuTracksCount(_viewId);
     value = value.copyWith(spuTracksCount: spuTracksCount);
     return spuTracksCount;
@@ -582,26 +553,20 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// The key parameter is the index of subtitle which is used for changing subtitle
   /// and the value is the display name of subtitle
   Future<Map<int, String>> getSpuTracks() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getSpuTracks');
     return await vlcPlayerPlatform.getSpuTracks(_viewId);
   }
 
   /// Change active subtitle index (set -1 to disable subtitle).
   /// [spuTrackNumber] - the subtitle index obtained from getSpuTracks()
   Future<void> setSpuTrack(int spuTrackNumber) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setSpuTrack');
     return await vlcPlayerPlatform.setSpuTrack(_viewId, spuTrackNumber);
   }
 
   /// Returns active spu track index
   Future<int> getSpuTrack() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getSpuTrack');
     var activeSpuTrack = await vlcPlayerPlatform.getSpuTrack(_viewId);
     value = value.copyWith(activeSpuTrack: activeSpuTrack);
     return activeSpuTrack;
@@ -610,18 +575,14 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// [spuDelay] - the amount of time in milliseconds which vlc subtitle should be delayed.
   /// (both positive & negative value applicable)
   Future<void> setSpuDelay(int spuDelay) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setSpuDelay');
     value = value.copyWith(spuDelay: spuDelay);
     return await vlcPlayerPlatform.setSpuDelay(_viewId, spuDelay);
   }
 
   /// Returns the amount of subtitle time delay.
   Future<int> getSpuDelay() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getSpuDelay');
     var spuDelay = await vlcPlayerPlatform.getSpuDelay(_viewId);
     value = value.copyWith(spuDelay: spuDelay);
     return spuDelay;
@@ -663,9 +624,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     DataSourceType dataSourceType,
     bool isSelected,
   }) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('addSubtitleTrack');
     return await vlcPlayerPlatform.addSubtitleTrack(
       _viewId,
       uri: uri,
@@ -676,9 +635,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   /// Returns the number of audio tracks
   Future<int> getAudioTracksCount() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getAudioTracksCount');
     var audioTracksCount = await vlcPlayerPlatform.getAudioTracksCount(_viewId);
     value = value.copyWith(audioTracksCount: audioTracksCount);
     return audioTracksCount;
@@ -688,17 +645,13 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// The key parameter is the index of audio track which is used for changing audio
   /// and the value is the display name of audio
   Future<Map<int, String>> getAudioTracks() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getAudioTracks');
     return await vlcPlayerPlatform.getAudioTracks(_viewId);
   }
 
   /// Returns active audio track index
   Future<int> getAudioTrack() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getAudioTrack');
     var activeAudioTrack = await vlcPlayerPlatform.getAudioTrack(_viewId);
     value = value.copyWith(activeAudioTrack: activeAudioTrack);
     return activeAudioTrack;
@@ -707,27 +660,21 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// Change active audio track index (set -1 to mute).
   /// [audioTrackNumber] - the audio track index obtained from getAudioTracks()
   Future<void> setAudioTrack(int audioTrackNumber) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setAudioTrack');
     return await vlcPlayerPlatform.setAudioTrack(_viewId, audioTrackNumber);
   }
 
   /// [audioDelay] - the amount of time in milliseconds which vlc audio should be delayed.
   /// (both positive & negative value appliable)
   Future<void> setAudioDelay(int audioDelay) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setAudioDelay');
     value = value.copyWith(audioDelay: audioDelay);
     return await vlcPlayerPlatform.setAudioDelay(_viewId, audioDelay);
   }
 
   /// Returns the amount of audio track time delay in millisecond.
   Future<int> getAudioDelay() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getAudioDelay');
     var audioDelay = await vlcPlayerPlatform.getAudioDelay(_viewId);
     value = value.copyWith(audioDelay: audioDelay);
     return audioDelay;
@@ -769,9 +716,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     DataSourceType dataSourceType,
     bool isSelected,
   }) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('addAudioTrack');
     return await vlcPlayerPlatform.addAudioTrack(
       _viewId,
       uri: uri,
@@ -782,9 +727,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
   /// Returns the number of video tracks
   Future<int> getVideoTracksCount() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getVideoTracksCount');
     var videoTracksCount = await vlcPlayerPlatform.getVideoTracksCount(_viewId);
     value = value.copyWith(videoTracksCount: videoTracksCount);
     return videoTracksCount;
@@ -793,26 +736,20 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// Returns all video tracks as array of <Int, String>
   /// The key parameter is the index of video track and the value is the display name of video track
   Future<Map<int, String>> getVideoTracks() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getVideoTracks');
     return await vlcPlayerPlatform.getVideoTracks(_viewId);
   }
 
   /// Change active video track index.
   /// [videoTrackNumber] - the video track index obtained from getVideoTracks()
   Future<void> setVideoTrack(int videoTrackNumber) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setVideoTrack');
     return await vlcPlayerPlatform.setVideoTrack(_viewId, videoTrackNumber);
   }
 
   /// Returns active video track index
   Future<int> getVideoTrack() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getVideoTrack');
     var activeVideoTrack = await vlcPlayerPlatform.getVideoTrack(_viewId);
     value = value.copyWith(activeVideoTrack: activeVideoTrack);
     return activeVideoTrack;
@@ -821,18 +758,14 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// [scale] - the video scale value
   /// Set video scale
   Future<void> setVideoScale(double videoScale) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setVideoScale');
     value = value.copyWith(videoScale: videoScale);
     return await vlcPlayerPlatform.setVideoScale(_viewId, videoScale);
   }
 
   /// Returns video scale
   Future<double> getVideoScale() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getVideoScale');
     var videoScale = await vlcPlayerPlatform.getVideoScale(_viewId);
     value = value.copyWith(videoScale: videoScale);
     return videoScale;
@@ -842,9 +775,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   ///
   /// Set video aspect ratio
   Future<void> setVideoAspectRatio(String aspectRatio) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('setVideoAspectRatio');
     return vlcPlayerPlatform.setVideoAspectRatio(_viewId, aspectRatio);
   }
 
@@ -852,45 +783,35 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   ///
   /// This is different from the aspectRatio property in video value "16:9"
   Future<String> getVideoAspectRatio() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getVideoAspectRatio');
     return vlcPlayerPlatform.getVideoAspectRatio(_viewId);
   }
 
   /// Returns binary data for a snapshot of the media at the current frame.
   ///
   Future<Uint8List> takeSnapshot() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('takeSnapshot');
     return await vlcPlayerPlatform.takeSnapshot(_viewId);
   }
 
   /// Start vlc cast discovery to find external display devices (chromecast)
   /// By setting serviceName, the vlc discovers renderer with that service
   Future<void> startRendererScanning({String rendererService}) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('startRendererScanning');
     return await vlcPlayerPlatform.startRendererScanning(viewId,
         rendererService: rendererService ?? '');
   }
 
   /// Stop vlc cast and scan
   Future<void> stopRendererScanning() async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('stopRendererScanning');
     return await vlcPlayerPlatform.stopRendererScanning(viewId);
   }
 
   /// Returns all detected renderer devices as array of <String, String>
   /// The key parameter is the name of cast device and the value is the display name of cast device
   Future<Map<String, String>> getRendererDevices() async {
-    if (!value.isInitialized || _isDisposed) {
-      return null;
-    }
+    _throwIfNotInitialized('getRendererDevices');
     return await vlcPlayerPlatform.getRendererDevices(_viewId);
   }
 
@@ -898,10 +819,23 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// Start vlc video casting to the selected device.
   /// Set null if you wanna stop video casting.
   Future<void> castToRenderer(String castDevice) async {
-    if (!value.isInitialized || _isDisposed) {
-      return;
-    }
+    _throwIfNotInitialized('castToRenderer');
     return await vlcPlayerPlatform.castToRenderer(_viewId, castDevice);
+  }
+
+  /// [functionName] - name of function
+  /// throw exception if vlc player controller is not initialized
+  void _throwIfNotInitialized(String functionName) {
+    if (!value.isInitialized) {
+      throw Exception(
+        '$functionName() was called on an uninitialized VlcPlayerController.',
+      );
+    }
+    if (_isDisposed) {
+      throw Exception(
+        '$functionName() was called on a disposed VlcPlayerController.',
+      );
+    }
   }
 
   /// [viewId] - the id of view that is generated by the platform

--- a/flutter_vlc_player_platform_interface/lib/src/method_channel/method_channel_vlc_player.dart
+++ b/flutter_vlc_player_platform_interface/lib/src/method_channel/method_channel_vlc_player.dart
@@ -30,8 +30,8 @@ class MethodChannelVlcPlayer extends VlcPlayerPlatform {
   }
 
   @override
-  Future<void> init() {
-    return _api.initialize();
+  Future<void> init() async {
+    return await _api.initialize();
   }
 
   @override
@@ -56,8 +56,8 @@ class MethodChannelVlcPlayer extends VlcPlayerPlatform {
   }
 
   @override
-  Future<void> dispose(int textureId) {
-    return _api.dispose(TextureMessage()..textureId = textureId);
+  Future<void> dispose(int textureId) async {
+    return await _api.dispose(TextureMessage()..textureId = textureId);
   }
 
   /// This method builds the appropriate platform view where the player
@@ -186,7 +186,7 @@ class MethodChannelVlcPlayer extends VlcPlayerPlatform {
 
   @override
   Future<void> setLooping(int textureId, bool looping) async {
-    return _api.setLooping(LoopingMessage()
+    return await _api.setLooping(LoopingMessage()
       ..textureId = textureId
       ..isLooping = looping);
   }
@@ -214,8 +214,8 @@ class MethodChannelVlcPlayer extends VlcPlayerPlatform {
   }
 
   @override
-  Future<void> seekTo(int textureId, Duration position) {
-    return _api.seekTo(PositionMessage()
+  Future<void> seekTo(int textureId, Duration position) async {
+    return await _api.seekTo(PositionMessage()
       ..textureId = textureId
       ..position = position.inMilliseconds);
   }

--- a/flutter_vlc_player_platform_interface/pubspec.yaml
+++ b/flutter_vlc_player_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_vlc_player_platform_interface
 description: A common platform interface for the flutter vlc player plugin.
 homepage: https://github.com/solid-software/flutter_vlc_player
-version: 1.0.1
+version: 1.0.2
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
Recently, @mitchross and I found there are situations that all variables & objects employed in vlc_player_controller are not disposed completely.
This could cause memory leak issue. This PR is a simple fix for the problem.