### PR TITLE
[Addition] Android 10 apps can't acess storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In order to load media/subtitle from internal device storage, you should put the
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 ```
-In some cases you also need to add the `android:requestLegacyExternalStorage="true"` flag to the Application tag in AndroidManifest.xml file.
+In some cases you also need to add the `android:requestLegacyExternalStorage="true"` flag to the Application tag in AndroidManifest.xml file to avoid acess denied errors. Android 10 apps can't acess storage without that flag. [reference](https://stackoverflow.com/a/60917774/14919621)
 
 After that you can access the media/subtitle file by 
 


### PR DESCRIPTION
Android 10 apps can't access storage if you don't have `android:requestLegacyExternalStorage="true"` flag in AndroidManifest.xml. Reference: https://stackoverflow.com/a/60917774/14919621

Its long time when my Xamarin apps were giving access denied errors in android 10 even I have read and write storage permissions. I solved by adding that flag. So its important to clarify here for future users.
Thanks.