### PR TITLE
Fix render overflows for top control bar and controls overlay in the example app.

### DIFF
--- a/flutter_vlc_player/example/lib/controls_overlay.dart
+++ b/flutter_vlc_player/example/lib/controls_overlay.dart
@@ -48,7 +48,7 @@ class ControlsOverlay extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.spaceAround,
                       children: [
                         IconButton(
-                          onPressed: _seekRelative(_seekStepBackward),
+                          onPressed: () => _seekRelative(_seekStepBackward),
                           color: _iconColor,
                           iconSize: _seekButtonIconSize,
                           icon: Icon(Icons.replay_10),
@@ -60,7 +60,7 @@ class ControlsOverlay extends StatelessWidget {
                           icon: Icon(Icons.play_arrow),
                         ),
                         IconButton(
-                          onPressed: _seekRelative(_seekStepForward),
+                          onPressed: () => _seekRelative(_seekStepForward),
                           color: _iconColor,
                           iconSize: _seekButtonIconSize,
                           icon: Icon(Icons.forward_10),
@@ -111,11 +111,9 @@ class ControlsOverlay extends StatelessWidget {
   }
 
   /// Returns a callback which seeks the video relative to current playing time.
-  VoidCallback _seekRelative(Duration seekStep) {
-    return () async {
-      if (controller.value.duration != null) {
-        await controller.seekTo(controller.value.position + seekStep);
-      }
-    };
+  Future<void> _seekRelative(Duration seekStep) async {
+    if (controller.value.duration != null) {
+      await controller.seekTo(controller.value.position + seekStep);
+    }
   }
 }

--- a/flutter_vlc_player/example/lib/controls_overlay.dart
+++ b/flutter_vlc_player/example/lib/controls_overlay.dart
@@ -52,7 +52,7 @@ class ControlsOverlay extends StatelessWidget {
                                 }
                               },
                               color: Colors.white,
-                              iconSize: 60.0,
+                              iconSize: 48.0,
                               icon: Icon(Icons.replay_10),
                             ),
                             IconButton(
@@ -60,7 +60,7 @@ class ControlsOverlay extends StatelessWidget {
                                 await controller.play();
                               },
                               color: Colors.white,
-                              iconSize: 100.0,
+                              iconSize: 80.0,
                               icon: Icon(Icons.play_arrow),
                             ),
                             IconButton(
@@ -72,7 +72,7 @@ class ControlsOverlay extends StatelessWidget {
                                 }
                               },
                               color: Colors.white,
-                              iconSize: 60.0,
+                              iconSize: 48.0,
                               icon: Icon(Icons.forward_10),
                             ),
                           ],

--- a/flutter_vlc_player/example/lib/controls_overlay.dart
+++ b/flutter_vlc_player/example/lib/controls_overlay.dart
@@ -24,11 +24,13 @@ class ControlsOverlay extends StatelessWidget {
         builder: (ctx) {
           if (controller.value.isEnded) {
             return Center(
-              child: IconButton(
-                onPressed: _replay,
-                color: _iconColor,
-                iconSize: _replayButtonIconSize,
-                icon: Icon(Icons.replay),
+              child: FittedBox(
+                child: IconButton(
+                  onPressed: _replay,
+                  color: _iconColor,
+                  iconSize: _replayButtonIconSize,
+                  icon: Icon(Icons.replay),
+                ),
               ),
             );
           }
@@ -40,29 +42,31 @@ class ControlsOverlay extends StatelessWidget {
               return SizedBox.expand(
                 child: Container(
                   color: Colors.black45,
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    mainAxisAlignment: MainAxisAlignment.spaceAround,
-                    children: [
-                      IconButton(
-                        onPressed: _seekRelative(_seekStepBackward),
-                        color: _iconColor,
-                        iconSize: _seekButtonIconSize,
-                        icon: Icon(Icons.replay_10),
-                      ),
-                      IconButton(
-                        onPressed: _play,
-                        color: _iconColor,
-                        iconSize: _playButtonIconSize,
-                        icon: Icon(Icons.play_arrow),
-                      ),
-                      IconButton(
-                        onPressed: _seekRelative(_seekStepForward),
-                        color: _iconColor,
-                        iconSize: _seekButtonIconSize,
-                        icon: Icon(Icons.forward_10),
-                      ),
-                    ],
+                  child: FittedBox(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        IconButton(
+                          onPressed: _seekRelative(_seekStepBackward),
+                          color: _iconColor,
+                          iconSize: _seekButtonIconSize,
+                          icon: Icon(Icons.replay_10),
+                        ),
+                        IconButton(
+                          onPressed: _play,
+                          color: _iconColor,
+                          iconSize: _playButtonIconSize,
+                          icon: Icon(Icons.play_arrow),
+                        ),
+                        IconButton(
+                          onPressed: _seekRelative(_seekStepForward),
+                          color: _iconColor,
+                          iconSize: _seekButtonIconSize,
+                          icon: Icon(Icons.forward_10),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               );
@@ -74,11 +78,13 @@ class ControlsOverlay extends StatelessWidget {
             case PlayingState.ended:
             case PlayingState.error:
               return Center(
-                child: IconButton(
-                  onPressed: _replay,
-                  color: _iconColor,
-                  iconSize: _replayButtonIconSize,
-                  icon: Icon(Icons.replay),
+                child: FittedBox(
+                  child: IconButton(
+                    onPressed: _replay,
+                    color: _iconColor,
+                    iconSize: _replayButtonIconSize,
+                    icon: Icon(Icons.replay),
+                  ),
                 ),
               );
             default:

--- a/flutter_vlc_player/example/lib/controls_overlay.dart
+++ b/flutter_vlc_player/example/lib/controls_overlay.dart
@@ -6,112 +6,110 @@ class ControlsOverlay extends StatelessWidget {
 
   final VlcPlayerController controller;
 
+  static const double _playButtonIconSize = 80;
+  static const double _replayButtonIconSize = 100;
+  static const double _seekButtonIconSize = 48;
+
+  static const Duration _seekStepForward = Duration(seconds: 10);
+  static const Duration _seekStepBackward = Duration(seconds: -10);
+
+  static const Color _iconColor = Colors.white;
+
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      fit: StackFit.expand,
-      children: <Widget>[
-        AnimatedSwitcher(
-          duration: Duration(milliseconds: 50),
-          reverseDuration: Duration(milliseconds: 200),
-          child: Builder(
-            builder: (ctx) {
-              if (controller.value.isEnded) {
-                return Center(
-                  child: IconButton(
-                    onPressed: () async {
-                      await controller.stop();
-                      await controller.play();
-                    },
-                    color: Colors.white,
-                    iconSize: 100.0,
-                    icon: Icon(Icons.replay),
+    return AnimatedSwitcher(
+      duration: Duration(milliseconds: 50),
+      reverseDuration: Duration(milliseconds: 200),
+      child: Builder(
+        builder: (ctx) {
+          if (controller.value.isEnded) {
+            return Center(
+              child: IconButton(
+                onPressed: _replay,
+                color: _iconColor,
+                iconSize: _replayButtonIconSize,
+                icon: Icon(Icons.replay),
+              ),
+            );
+          }
+
+          switch (controller.value.playingState) {
+            case PlayingState.initialized:
+            case PlayingState.stopped:
+            case PlayingState.paused:
+              return SizedBox.expand(
+                child: Container(
+                  color: Colors.black45,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      IconButton(
+                        onPressed: _seekRelative(_seekStepBackward),
+                        color: _iconColor,
+                        iconSize: _seekButtonIconSize,
+                        icon: Icon(Icons.replay_10),
+                      ),
+                      IconButton(
+                        onPressed: _play,
+                        color: _iconColor,
+                        iconSize: _playButtonIconSize,
+                        icon: Icon(Icons.play_arrow),
+                      ),
+                      IconButton(
+                        onPressed: _seekRelative(_seekStepForward),
+                        color: _iconColor,
+                        iconSize: _seekButtonIconSize,
+                        icon: Icon(Icons.forward_10),
+                      ),
+                    ],
                   ),
-                );
-              } else {
-                switch (controller.value.playingState) {
-                  case PlayingState.initializing:
-                    return CircularProgressIndicator();
+                ),
+              );
 
-                  case PlayingState.initialized:
-                  case PlayingState.stopped:
-                  case PlayingState.paused:
-                    return SizedBox.expand(
-                      child: Container(
-                        color: Colors.black45,
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          children: [
-                            IconButton(
-                              onPressed: () async {
-                                if (controller.value.duration != null) {
-                                  await controller.seekTo(
-                                      controller.value.position -
-                                          Duration(seconds: 10));
-                                }
-                              },
-                              color: Colors.white,
-                              iconSize: 48.0,
-                              icon: Icon(Icons.replay_10),
-                            ),
-                            IconButton(
-                              onPressed: () async {
-                                await controller.play();
-                              },
-                              color: Colors.white,
-                              iconSize: 80.0,
-                              icon: Icon(Icons.play_arrow),
-                            ),
-                            IconButton(
-                              onPressed: () async {
-                                if (controller.value.duration != null) {
-                                  await controller.seekTo(
-                                      controller.value.position +
-                                          Duration(seconds: 10));
-                                }
-                              },
-                              color: Colors.white,
-                              iconSize: 48.0,
-                              icon: Icon(Icons.forward_10),
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
+            case PlayingState.buffering:
+            case PlayingState.playing:
+              return GestureDetector(onTap: _pause);
 
-                  case PlayingState.buffering:
-                  case PlayingState.playing:
-                    return SizedBox.shrink();
-
-                  case PlayingState.ended:
-                  case PlayingState.error:
-                    return Center(
-                      child: IconButton(
-                        onPressed: () async {
-                          await controller.play();
-                        },
-                        color: Colors.white,
-                        iconSize: 100.0,
-                        icon: Icon(Icons.replay),
-                      ),
-                    );
-                }
-              }
+            case PlayingState.ended:
+            case PlayingState.error:
+              return Center(
+                child: IconButton(
+                  onPressed: _replay,
+                  color: _iconColor,
+                  iconSize: _replayButtonIconSize,
+                  icon: Icon(Icons.replay),
+                ),
+              );
+            default:
               return SizedBox.shrink();
-            },
-          ),
-        ),
-        GestureDetector(
-          onTap: !controller.value.isPlaying
-              ? null
-              : () async {
-                  if (controller.value.isPlaying) {
-                    await controller.pause();
-                  }
-                },
-        ),
-      ],
+          }
+        },
+      ),
     );
+  }
+
+  Future<void> _play() {
+    return controller.play();
+  }
+
+  Future<void> _replay() async {
+    await controller.stop();
+    await controller.play();
+  }
+
+  Future<void> _pause() async {
+    if (controller.value.isPlaying) {
+      await controller.pause();
+    }
+  }
+
+  /// Returns a callback which seeks the video relative to current playing time.
+  VoidCallback _seekRelative(Duration seekStep) {
+    return () async {
+      if (controller.value.duration != null) {
+        await controller.seekTo(controller.value.position + seekStep);
+      }
+    };
   }
 }

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -23,6 +23,8 @@ class VlcPlayerWithControls extends StatefulWidget {
 
 class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
     with AutomaticKeepAliveClientMixin {
+  static const _playerControlsBgColor = Colors.black87;
+
   VlcPlayerController _controller;
 
   //
@@ -95,166 +97,159 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
       children: [
         Visibility(
           visible: widget.showControls,
-          child: SizedBox(
+          child: Container(
             width: double.infinity,
-            child: Container(
-              color: Colors.black87,
-              child: Wrap(
-                alignment: WrapAlignment.spaceBetween,
-                children: [
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Stack(
-                        children: [
-                          IconButton(
-                            tooltip: 'Get Subtitle Tracks',
-                            icon: Icon(Icons.closed_caption),
-                            color: Colors.white,
-                            onPressed: () {
-                              _getSubtitleTracks();
-                            },
-                          ),
-                          Positioned(
-                            top: 8,
-                            right: 8,
-                            child: IgnorePointer(
-                              child: Container(
-                                decoration: BoxDecoration(
-                                  color: Colors.orange,
-                                  borderRadius: BorderRadius.circular(1),
-                                ),
-                                padding: EdgeInsets.symmetric(
-                                  vertical: 1,
-                                  horizontal: 2,
-                                ),
-                                child: Text(
-                                  '$numberOfCaptions',
-                                  style: TextStyle(
-                                    color: Colors.black,
-                                    fontSize: 10,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      Stack(
-                        children: [
-                          IconButton(
-                              tooltip: 'Get Audio Tracks',
-                              icon: Icon(Icons.audiotrack),
-                              color: Colors.white,
-                              onPressed: _getAudioTracks),
-                          Positioned(
-                            top: 8,
-                            right: 8,
-                            child: IgnorePointer(
-                              child: Container(
-                                decoration: BoxDecoration(
-                                  color: Colors.orange,
-                                  borderRadius: BorderRadius.circular(1),
-                                ),
-                                padding: EdgeInsets.symmetric(
-                                    vertical: 1, horizontal: 2),
-                                child: Text(
-                                  '$numberOfAudioTracks',
-                                  style: TextStyle(
-                                    color: Colors.black,
-                                    fontSize: 10,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      Stack(
-                        children: [
-                          IconButton(
-                            icon: Icon(Icons.timer),
-                            color: Colors.white,
-                            onPressed: () async {
-                              playbackSpeedIndex++;
-                              if (playbackSpeedIndex >= playbackSpeeds.length) {
-                                playbackSpeedIndex = 0;
-                              }
-                              return await _controller.setPlaybackSpeed(
-                                  playbackSpeeds.elementAt(playbackSpeedIndex));
-                            },
-                          ),
-                          Positioned(
-                            bottom: 7,
-                            right: 3,
-                            child: IgnorePointer(
-                              child: Container(
-                                decoration: BoxDecoration(
-                                  color: Colors.orange,
-                                  borderRadius: BorderRadius.circular(1),
-                                ),
-                                padding: EdgeInsets.symmetric(
-                                  vertical: 1,
-                                  horizontal: 2,
-                                ),
-                                child: Text(
-                                  '${playbackSpeeds.elementAt(playbackSpeedIndex)}x',
-                                  style: TextStyle(
-                                    color: Colors.black,
-                                    fontSize: 8,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      IconButton(
-                        tooltip: 'Get Snapshot',
-                        icon: Icon(Icons.camera),
-                        color: Colors.white,
-                        onPressed: _createCameraImage,
-                      ),
-                      IconButton(
-                          icon: Icon(Icons.cast),
-                          color: Colors.white,
-                          onPressed: _getRendererDevices),
-                    ],
-                  ),
-                  Container(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
+            color: _playerControlsBgColor,
+            child: Wrap(
+              alignment: WrapAlignment.spaceBetween,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Stack(
                       children: [
-                        Text(
-                          'Size: ' +
-                              (_controller.value.size?.width?.toInt() ?? 0)
-                                  .toString() +
-                              'x' +
-                              (_controller.value.size?.height?.toInt() ?? 0)
-                                  .toString(),
-                          textAlign: TextAlign.center,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(color: Colors.white, fontSize: 10),
+                        IconButton(
+                          tooltip: 'Get Subtitle Tracks',
+                          icon: Icon(Icons.closed_caption),
+                          color: Colors.white,
+                          onPressed: _getSubtitleTracks,
                         ),
-                        SizedBox(height: 5),
-                        Text(
-                          'Status: ' +
-                              _controller.value.playingState
-                                  .toString()
-                                  .split('.')[1],
-                          textAlign: TextAlign.center,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(color: Colors.white, fontSize: 10),
+                        Positioned(
+                          top: 8,
+                          right: 8,
+                          child: IgnorePointer(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: Colors.orange,
+                                borderRadius: BorderRadius.circular(1),
+                              ),
+                              padding: EdgeInsets.symmetric(
+                                vertical: 1,
+                                horizontal: 2,
+                              ),
+                              child: Text(
+                                '$numberOfCaptions',
+                                style: TextStyle(
+                                  color: Colors.black,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ),
                         ),
                       ],
                     ),
+                    Stack(
+                      children: [
+                        IconButton(
+                          tooltip: 'Get Audio Tracks',
+                          icon: Icon(Icons.audiotrack),
+                          color: Colors.white,
+                          onPressed: _getAudioTracks,
+                        ),
+                        Positioned(
+                          top: 8,
+                          right: 8,
+                          child: IgnorePointer(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: Colors.orange,
+                                borderRadius: BorderRadius.circular(1),
+                              ),
+                              padding: EdgeInsets.symmetric(
+                                vertical: 1,
+                                horizontal: 2,
+                              ),
+                              child: Text(
+                                '$numberOfAudioTracks',
+                                style: TextStyle(
+                                  color: Colors.black,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    Stack(
+                      children: [
+                        IconButton(
+                          icon: Icon(Icons.timer),
+                          color: Colors.white,
+                          onPressed: _cyclePlaybackSpeed,
+                        ),
+                        Positioned(
+                          bottom: 7,
+                          right: 3,
+                          child: IgnorePointer(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: Colors.orange,
+                                borderRadius: BorderRadius.circular(1),
+                              ),
+                              padding: EdgeInsets.symmetric(
+                                vertical: 1,
+                                horizontal: 2,
+                              ),
+                              child: Text(
+                                '${playbackSpeeds.elementAt(playbackSpeedIndex)}x',
+                                style: TextStyle(
+                                  color: Colors.black,
+                                  fontSize: 8,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    IconButton(
+                      tooltip: 'Get Snapshot',
+                      icon: Icon(Icons.camera),
+                      color: Colors.white,
+                      onPressed: _createCameraImage,
+                    ),
+                    IconButton(
+                      icon: Icon(Icons.cast),
+                      color: Colors.white,
+                      onPressed: _getRendererDevices,
+                    ),
+                  ],
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'Size: ' +
+                            (_controller.value.size?.width?.toInt() ?? 0)
+                                .toString() +
+                            'x' +
+                            (_controller.value.size?.height?.toInt() ?? 0)
+                                .toString(),
+                        textAlign: TextAlign.center,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(color: Colors.white, fontSize: 10),
+                      ),
+                      SizedBox(height: 5),
+                      Text(
+                        'Status: ' +
+                            _controller.value.playingState
+                                .toString()
+                                .split('.')[1],
+                        textAlign: TextAlign.center,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(color: Colors.white, fontSize: 10),
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),
@@ -279,7 +274,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
         Visibility(
           visible: widget.showControls,
           child: Container(
-            color: Colors.black87,
+            color: _playerControlsBgColor,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
@@ -288,11 +283,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
                   icon: _controller.value.isPlaying
                       ? Icon(Icons.pause_circle_outline)
                       : Icon(Icons.play_circle_outline),
-                  onPressed: () async {
-                    return _controller.value.isPlaying
-                        ? await _controller.pause()
-                        : await _controller.play();
-                  },
+                  onPressed: _togglePlaying,
                 ),
                 Expanded(
                   child: Row(
@@ -314,7 +305,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
                               ? 1.0
                               : _controller.value.duration.inSeconds.toDouble(),
                           onChanged:
-                              !validPosition ? null : _onSliderPositionChanged,
+                              validPosition ? _onSliderPositionChanged : null,
                         ),
                       ),
                       Text(
@@ -336,7 +327,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
         Visibility(
           visible: widget.showControls,
           child: Container(
-            color: Colors.black87,
+            color: _playerControlsBgColor,
             padding: const EdgeInsets.symmetric(horizontal: 8.0),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -351,12 +342,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
                     min: 0,
                     max: 100,
                     value: volumeValue,
-                    onChanged: (value) {
-                      setState(() {
-                        volumeValue = value;
-                      });
-                      _controller.setVolume(volumeValue.toInt());
-                    },
+                    onChanged: _setSoundVolume,
                   ),
                 ),
                 Icon(
@@ -369,6 +355,28 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
         ),
       ],
     );
+  }
+
+  void _cyclePlaybackSpeed() async {
+    playbackSpeedIndex++;
+    if (playbackSpeedIndex >= playbackSpeeds.length) {
+      playbackSpeedIndex = 0;
+    }
+    return await _controller
+        .setPlaybackSpeed(playbackSpeeds.elementAt(playbackSpeedIndex));
+  }
+
+  void _setSoundVolume(value) {
+    setState(() {
+      volumeValue = value;
+    });
+    _controller.setVolume(volumeValue.toInt());
+  }
+
+  void _togglePlaying() async {
+    return _controller.value.isPlaying
+        ? await _controller.pause()
+        : await _controller.play();
   }
 
   void _onSliderPositionChanged(double progress) {

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -103,8 +103,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
             child: Wrap(
               alignment: WrapAlignment.spaceBetween,
               children: [
-                Row(
-                  mainAxisSize: MainAxisSize.min,
+                Wrap(
                   children: [
                     Stack(
                       children: [

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -373,7 +373,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
   }
 
   void _togglePlaying() async {
-    return _controller.value.isPlaying
+   _controller.value.isPlaying
         ? await _controller.pause()
         : await _controller.play();
   }

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -95,171 +95,166 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
       children: [
         Visibility(
           visible: widget.showControls,
-          child: Container(
-            height: 50,
-            color: Colors.black87,
-            child: Row(
-              children: [
-                ListView(
-                  scrollDirection: Axis.horizontal,
-                  shrinkWrap: true,
-                  children: [
-                    Stack(
-                      children: [
-                        IconButton(
-                          tooltip: 'Get Subtitle Tracks',
-                          icon: Icon(Icons.closed_caption),
-                          color: Colors.white,
-                          onPressed: () {
-                            _getSubtitleTracks();
-                          },
-                        ),
-                        Positioned(
-                          top: 8,
-                          right: 8,
-                          child: IgnorePointer(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                color: Colors.orange,
-                                borderRadius: BorderRadius.circular(1),
-                              ),
-                              padding: EdgeInsets.symmetric(
-                                  vertical: 1, horizontal: 2),
-                              child: Text(
-                                '$numberOfCaptions',
-                                style: TextStyle(
-                                  color: Colors.black,
-                                  fontSize: 10,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    Stack(
-                      children: [
-                        IconButton(
-                          tooltip: 'Get Audio Tracks',
-                          icon: Icon(Icons.audiotrack),
-                          color: Colors.white,
-                          onPressed: () {
-                            _getAudioTracks();
-                          },
-                        ),
-                        Positioned(
-                          top: 8,
-                          right: 8,
-                          child: IgnorePointer(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                color: Colors.orange,
-                                borderRadius: BorderRadius.circular(1),
-                              ),
-                              padding: EdgeInsets.symmetric(
-                                  vertical: 1, horizontal: 2),
-                              child: Text(
-                                '$numberOfAudioTracks',
-                                style: TextStyle(
-                                  color: Colors.black,
-                                  fontSize: 10,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    Stack(
-                      children: [
-                        IconButton(
-                          icon: Icon(Icons.timer),
-                          color: Colors.white,
-                          onPressed: () async {
-                            playbackSpeedIndex++;
-                            if (playbackSpeedIndex >= playbackSpeeds.length) {
-                              playbackSpeedIndex = 0;
-                            }
-                            return await _controller.setPlaybackSpeed(
-                                playbackSpeeds.elementAt(playbackSpeedIndex));
-                          },
-                        ),
-                        Positioned(
-                          bottom: 7,
-                          right: 3,
-                          child: IgnorePointer(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                color: Colors.orange,
-                                borderRadius: BorderRadius.circular(1),
-                              ),
-                              padding: EdgeInsets.symmetric(
-                                  vertical: 1, horizontal: 2),
-                              child: Text(
-                                '${playbackSpeeds.elementAt(playbackSpeedIndex)}x',
-                                style: TextStyle(
-                                  color: Colors.black,
-                                  fontSize: 8,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    IconButton(
-                      tooltip: 'Get Snapshot',
-                      icon: Icon(Icons.camera),
-                      color: Colors.white,
-                      onPressed: () {
-                        _createCameraImage();
-                      },
-                    ),
-                    IconButton(
-                      icon: Icon(Icons.cast),
-                      color: Colors.white,
-                      onPressed: () async {
-                        _getRendererDevices();
-                      },
-                    ),
-                  ],
-                ),
-                Expanded(
-                  child: Container(),
-                ),
-                Container(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
+          child: SizedBox(
+            width: double.infinity,
+            child: Container(
+              color: Colors.black87,
+              child: Wrap(
+                alignment: WrapAlignment.spaceBetween,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
                     children: [
-                      Text(
-                        'Size: ' +
-                            (_controller.value.size?.width?.toInt() ?? 0)
-                                .toString() +
-                            'x' +
-                            (_controller.value.size?.height?.toInt() ?? 0)
-                                .toString(),
-                        textAlign: TextAlign.center,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(color: Colors.white, fontSize: 10),
+                      Stack(
+                        children: [
+                          IconButton(
+                            tooltip: 'Get Subtitle Tracks',
+                            icon: Icon(Icons.closed_caption),
+                            color: Colors.white,
+                            onPressed: () {
+                              _getSubtitleTracks();
+                            },
+                          ),
+                          Positioned(
+                            top: 8,
+                            right: 8,
+                            child: IgnorePointer(
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.orange,
+                                  borderRadius: BorderRadius.circular(1),
+                                ),
+                                padding: EdgeInsets.symmetric(
+                                  vertical: 1,
+                                  horizontal: 2,
+                                ),
+                                child: Text(
+                                  '$numberOfCaptions',
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
-                      SizedBox(height: 5),
-                      Text(
-                        'Status: ' +
-                            _controller.value.playingState
-                                .toString()
-                                .split('.')[1],
-                        textAlign: TextAlign.center,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(color: Colors.white, fontSize: 10),
+                      Stack(
+                        children: [
+                          IconButton(
+                              tooltip: 'Get Audio Tracks',
+                              icon: Icon(Icons.audiotrack),
+                              color: Colors.white,
+                              onPressed: _getAudioTracks),
+                          Positioned(
+                            top: 8,
+                            right: 8,
+                            child: IgnorePointer(
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.orange,
+                                  borderRadius: BorderRadius.circular(1),
+                                ),
+                                padding: EdgeInsets.symmetric(
+                                    vertical: 1, horizontal: 2),
+                                child: Text(
+                                  '$numberOfAudioTracks',
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
+                      Stack(
+                        children: [
+                          IconButton(
+                            icon: Icon(Icons.timer),
+                            color: Colors.white,
+                            onPressed: () async {
+                              playbackSpeedIndex++;
+                              if (playbackSpeedIndex >= playbackSpeeds.length) {
+                                playbackSpeedIndex = 0;
+                              }
+                              return await _controller.setPlaybackSpeed(
+                                  playbackSpeeds.elementAt(playbackSpeedIndex));
+                            },
+                          ),
+                          Positioned(
+                            bottom: 7,
+                            right: 3,
+                            child: IgnorePointer(
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.orange,
+                                  borderRadius: BorderRadius.circular(1),
+                                ),
+                                padding: EdgeInsets.symmetric(
+                                  vertical: 1,
+                                  horizontal: 2,
+                                ),
+                                child: Text(
+                                  '${playbackSpeeds.elementAt(playbackSpeedIndex)}x',
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontSize: 8,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      IconButton(
+                        tooltip: 'Get Snapshot',
+                        icon: Icon(Icons.camera),
+                        color: Colors.white,
+                        onPressed: _createCameraImage,
+                      ),
+                      IconButton(
+                          icon: Icon(Icons.cast),
+                          color: Colors.white,
+                          onPressed: _getRendererDevices),
                     ],
                   ),
-                ),
-              ],
+                  Container(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          'Size: ' +
+                              (_controller.value.size?.width?.toInt() ?? 0)
+                                  .toString() +
+                              'x' +
+                              (_controller.value.size?.height?.toInt() ?? 0)
+                                  .toString(),
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(color: Colors.white, fontSize: 10),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          'Status: ' +
+                              _controller.value.playingState
+                                  .toString()
+                                  .split('.')[1],
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(color: Colors.white, fontSize: 10),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -284,7 +279,6 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
         Visibility(
           visible: widget.showControls,
           child: Container(
-            height: 50,
             color: Colors.black87,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,


### PR DESCRIPTION
Alternative to PR #201 

- Fixed top control bar overflow by wrapping the elements when necessary.
- Fixed control overlay overflow on small screens (<= 256px).

![image](https://user-images.githubusercontent.com/40931732/111452853-99da0100-871b-11eb-838a-f14ac493d1d5.png)
![image](https://user-images.githubusercontent.com/40931732/111452914-abbba400-871b-11eb-95e9-a1d15654680b.png)

Layout looks unchanged on higher resolution:
![image](https://user-images.githubusercontent.com/40931732/111453037-d0b01700-871b-11eb-8e49-a5f0fd27fd4a.png)


