### PR TITLE
Avoid FlutterVlcPlayerFactory new instances onAttachedToActivity

### DIFF
--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
@@ -56,22 +56,24 @@ public class FlutterVlcPlayerPlugin implements FlutterPlugin, ActivityAware {
     @RequiresApi(api = Build.VERSION_CODES.N)
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-        final FlutterInjector injector = FlutterInjector.instance();
-        //
-        flutterVlcPlayerFactory =
-                new FlutterVlcPlayerFactory(
-                        flutterPluginBinding.getBinaryMessenger(),
-                        flutterPluginBinding.getTextureRegistry(),
-                        injector.flutterLoader()::getLookupKeyForAsset,
-                        injector.flutterLoader()::getLookupKeyForAsset
-                );
-        flutterPluginBinding
-                .getPlatformViewRegistry()
-                .registerViewFactory(
-                        VIEW_TYPE,
-                        flutterVlcPlayerFactory
-                );
-        //
+        if(flutterVlcPlayerFactory == null) {
+            final FlutterInjector injector = FlutterInjector.instance();
+            //
+            flutterVlcPlayerFactory =
+                    new FlutterVlcPlayerFactory(
+                            flutterPluginBinding.getBinaryMessenger(),
+                            flutterPluginBinding.getTextureRegistry(),
+                            injector.flutterLoader()::getLookupKeyForAsset,
+                            injector.flutterLoader()::getLookupKeyForAsset
+                    );
+            flutterPluginBinding
+                    .getPlatformViewRegistry()
+                    .registerViewFactory(
+                            VIEW_TYPE,
+                            flutterVlcPlayerFactory
+                    );
+            //
+        }
         startListening();
     }
 

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
@@ -22,19 +22,21 @@ public class FlutterVlcPlayerPlugin implements FlutterPlugin, ActivityAware {
 
     @SuppressWarnings("deprecation")
     public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-        flutterVlcPlayerFactory =
-                new FlutterVlcPlayerFactory(
-                        registrar.messenger(),
-                        registrar.textures(),
-                        registrar::lookupKeyForAsset,
-                        registrar::lookupKeyForAsset
-                );
-        registrar
-                .platformViewRegistry()
-                .registerViewFactory(
-                        VIEW_TYPE,
-                        flutterVlcPlayerFactory
-                );
+        if (flutterVlcPlayerFactory == null) {
+            flutterVlcPlayerFactory =
+                    new FlutterVlcPlayerFactory(
+                            registrar.messenger(),
+                            registrar.textures(),
+                            registrar::lookupKeyForAsset,
+                            registrar::lookupKeyForAsset
+                    );
+            registrar
+                    .platformViewRegistry()
+                    .registerViewFactory(
+                            VIEW_TYPE,
+                            flutterVlcPlayerFactory
+                    );
+        }
         registrar.addViewDestroyListener(view -> {
             stopListening();
             return false;
@@ -56,7 +58,7 @@ public class FlutterVlcPlayerPlugin implements FlutterPlugin, ActivityAware {
     @RequiresApi(api = Build.VERSION_CODES.N)
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-        if(flutterVlcPlayerFactory == null) {
+        if (flutterVlcPlayerFactory == null) {
             final FlutterInjector injector = FlutterInjector.instance();
             //
             flutterVlcPlayerFactory =


### PR DESCRIPTION
The player works great in a Flutter application, but I ran into a problem in an Android project that uses Flutter as a module. 

Every time I started the flutter screens again, The VLC Player no longer plays the video, this was because a new instance of the FlutterVlcPlayerFactory was created in the onAttachedToActivity method, which was executed every time I opened the Flutter Engine Activity. 

This was the solution I made to avoid new instances for cases where Flutter is used as a module in a native project.