### PR TITLE
improved vlc controller events & callbacks code

### DIFF
--- a/flutter_vlc_player/CHANGELOG.md
+++ b/flutter_vlc_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.2
+* Fix issue with vlc error event
+* Added onInit & onRenderer listeners
+Credits to Alireza Setayesh (https://github.com/alr2413) and solid-vovabeloded (https://github.com/solid-vovabeloded).
+
 ## 6.0.1
 * Fix issue with black screen / offstage
 Credits to Mitch Ross (https://github.com/mitchross)

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
@@ -50,8 +50,8 @@ final class FlutterVlcPlayer implements PlatformView {
     //
     private LibVLC libVLC;
     private MediaPlayer mediaPlayer;
-    private List<RendererDiscoverer> rendererDiscoverers;
-    private List<RendererItem> rendererItems;
+    private List<RendererDiscoverer> rendererDiscoverers = new ArrayList<>();;
+    private List<RendererItem> rendererItems = new ArrayList<>();;
     private boolean isDisposed = false;
 
     // Platform view

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayerPlugin.java
@@ -22,19 +22,21 @@ public class FlutterVlcPlayerPlugin implements FlutterPlugin, ActivityAware {
 
     @SuppressWarnings("deprecation")
     public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-        flutterVlcPlayerFactory =
-                new FlutterVlcPlayerFactory(
-                        registrar.messenger(),
-                        registrar.textures(),
-                        registrar::lookupKeyForAsset,
-                        registrar::lookupKeyForAsset
-                );
-        registrar
-                .platformViewRegistry()
-                .registerViewFactory(
-                        VIEW_TYPE,
-                        flutterVlcPlayerFactory
-                );
+        if (flutterVlcPlayerFactory == null) {
+            flutterVlcPlayerFactory =
+                    new FlutterVlcPlayerFactory(
+                            registrar.messenger(),
+                            registrar.textures(),
+                            registrar::lookupKeyForAsset,
+                            registrar::lookupKeyForAsset
+                    );
+            registrar
+                    .platformViewRegistry()
+                    .registerViewFactory(
+                            VIEW_TYPE,
+                            flutterVlcPlayerFactory
+                    );
+        }
         registrar.addViewDestroyListener(view -> {
             stopListening();
             return false;
@@ -56,22 +58,24 @@ public class FlutterVlcPlayerPlugin implements FlutterPlugin, ActivityAware {
     @RequiresApi(api = Build.VERSION_CODES.N)
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-        final FlutterInjector injector = FlutterInjector.instance();
-        //
-        flutterVlcPlayerFactory =
-                new FlutterVlcPlayerFactory(
-                        flutterPluginBinding.getBinaryMessenger(),
-                        flutterPluginBinding.getTextureRegistry(),
-                        injector.flutterLoader()::getLookupKeyForAsset,
-                        injector.flutterLoader()::getLookupKeyForAsset
-                );
-        flutterPluginBinding
-                .getPlatformViewRegistry()
-                .registerViewFactory(
-                        VIEW_TYPE,
-                        flutterVlcPlayerFactory
-                );
-        //
+        if (flutterVlcPlayerFactory == null) {
+            final FlutterInjector injector = FlutterInjector.instance();
+            //
+            flutterVlcPlayerFactory =
+                    new FlutterVlcPlayerFactory(
+                            flutterPluginBinding.getBinaryMessenger(),
+                            flutterPluginBinding.getTextureRegistry(),
+                            injector.flutterLoader()::getLookupKeyForAsset,
+                            injector.flutterLoader()::getLookupKeyForAsset
+                    );
+            flutterPluginBinding
+                    .getPlatformViewRegistry()
+                    .registerViewFactory(
+                            VIEW_TYPE,
+                            flutterVlcPlayerFactory
+                    );
+            //
+        }
         startListening();
     }
 

--- a/flutter_vlc_player/example/lib/controls_overlay.dart
+++ b/flutter_vlc_player/example/lib/controls_overlay.dart
@@ -22,7 +22,7 @@ class ControlsOverlay extends StatelessWidget {
       reverseDuration: Duration(milliseconds: 200),
       child: Builder(
         builder: (ctx) {
-          if (controller.value.isEnded) {
+          if (controller.value.isEnded || controller.value.hasError) {
             return Center(
               child: FittedBox(
                 child: IconButton(

--- a/flutter_vlc_player/example/lib/multiple_tab.dart
+++ b/flutter_vlc_player/example/lib/multiple_tab.dart
@@ -28,7 +28,6 @@ class _MultipleTabState extends State<MultipleTab> {
         urls[i],
         hwAcc: HwAcc.FULL,
         autoPlay: false,
-        onInit: () async {},
         options: VlcPlayerOptions(
           advanced: VlcAdvancedOptions([
             VlcAdvancedOptions.networkCaching(2000),

--- a/flutter_vlc_player/example/lib/single_tab.dart
+++ b/flutter_vlc_player/example/lib/single_tab.dart
@@ -38,7 +38,7 @@ class _SingleTabState extends State<SingleTab> {
     listVideos.add(VideoData(
       name: 'Network Video 1',
       path:
-          'http://samples.mplayerhq.hu/MPEG-4/embedded_subs/1Video_2Audio_2SUBs_timed_text_streams_.mp4',
+          'http://samples.mplayerhq.hu/MPEG-4/embedded_subs/1Video_2Audio_2SUBs_timed_text_streams_.mp42',
       type: VideoType.network,
     ));
     //
@@ -186,8 +186,10 @@ class _SingleTabState extends State<SingleTab> {
               onTap: () async {
                 switch (video.type) {
                   case VideoType.network:
-                    await _controller.setMediaFromNetwork(video.path,
-                        hwAcc: HwAcc.FULL);
+                    await _controller.setMediaFromNetwork(
+                      video.path,
+                      hwAcc: HwAcc.FULL,
+                    );
                     break;
                   case VideoType.file:
                     ScaffoldMessenger.of(context).showSnackBar(

--- a/flutter_vlc_player/example/lib/single_tab.dart
+++ b/flutter_vlc_player/example/lib/single_tab.dart
@@ -82,12 +82,6 @@ class _SingleTabState extends State<SingleTab> {
         _controller = VlcPlayerController.network(
           initVideo.path,
           hwAcc: HwAcc.FULL,
-          onInit: () async {
-            await _controller.startRendererScanning();
-          },
-          onRendererHandler: (type, id, name) {
-            print('onRendererHandler $type $id $name');
-          },
           options: VlcPlayerOptions(
             advanced: VlcAdvancedOptions([
               VlcAdvancedOptions.networkCaching(2000),
@@ -110,27 +104,21 @@ class _SingleTabState extends State<SingleTab> {
         var file = File(initVideo.path);
         _controller = VlcPlayerController.file(
           file,
-          onInit: () async {
-            await _controller.startRendererScanning();
-          },
-          onRendererHandler: (type, id, name) {
-            print('onRendererHandler $type $id $name');
-          },
         );
         break;
       case VideoType.asset:
         _controller = VlcPlayerController.asset(
           initVideo.path,
-          onInit: () async {
-            await _controller.startRendererScanning();
-          },
-          onRendererHandler: (type, id, name) {
-            print('onRendererHandler $type $id $name');
-          },
           options: VlcPlayerOptions(),
         );
         break;
     }
+    _controller.addOnInitListener(() async {
+      await _controller.startRendererScanning();
+    });
+    _controller.addOnRendererEventListener((type, id, name) {
+      print('OnRendererEventListener $type $id $name');
+    });
   }
 
   @override

--- a/flutter_vlc_player/example/lib/single_tab.dart
+++ b/flutter_vlc_player/example/lib/single_tab.dart
@@ -38,7 +38,7 @@ class _SingleTabState extends State<SingleTab> {
     listVideos.add(VideoData(
       name: 'Network Video 1',
       path:
-          'http://samples.mplayerhq.hu/MPEG-4/embedded_subs/1Video_2Audio_2SUBs_timed_text_streams_.mp42',
+          'http://samples.mplayerhq.hu/MPEG-4/embedded_subs/1Video_2Audio_2SUBs_timed_text_streams_.mp4',
       type: VideoType.network,
     ));
     //

--- a/flutter_vlc_player/lib/src/vlc_player_controller.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_controller.dart
@@ -162,7 +162,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
             isBuffering: true,
             isEnded: false,
             playingState: PlayingState.buffering,
-            errorDescription: null,
+            errorDescription: VlcPlayerValue.emptyString,
           );
           break;
 
@@ -196,7 +196,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
             activeAudioTrack: event.activeAudioTrack,
             spuTracksCount: event.spuTracksCount,
             activeSpuTrack: event.activeSpuTrack,
-            errorDescription: null,
+            errorDescription: VlcPlayerValue.emptyString,
           );
           break;
 
@@ -228,7 +228,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
             playingState: (event.isPlaying ?? false)
                 ? PlayingState.playing
                 : value.playingState,
-            errorDescription: null,
+            errorDescription: VlcPlayerValue.emptyString,
           );
           break;
 
@@ -237,11 +237,12 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
 
         case VlcMediaEventType.error:
           value = value.copyWith(
-              isPlaying: false,
-              isBuffering: false,
-              isEnded: false,
-              playingState: PlayingState.error,
-              errorDescription: 'VLC encountered an error!');
+            isPlaying: false,
+            isBuffering: false,
+            isEnded: false,
+            playingState: PlayingState.error,
+            errorDescription: 'VLC encountered an error!',
+          );
           break;
 
         case VlcMediaEventType.unknown:

--- a/flutter_vlc_player/lib/src/vlc_player_controller.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_controller.dart
@@ -214,7 +214,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
         case VlcMediaEventType.timeChanged:
           value = value.copyWith(
             isEnded: false,
-            isBuffering: (event.mediaEventType == VlcMediaEventType.buffering),
+            isBuffering: event.mediaEventType == VlcMediaEventType.buffering,
             position: event.position,
             duration: event.duration,
             playbackSpeed: event.playbackSpeed,

--- a/flutter_vlc_player/lib/src/vlc_player_controller.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_controller.dart
@@ -35,8 +35,10 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     this.hwAcc = HwAcc.AUTO,
     this.autoPlay = true,
     this.options,
-    @deprecated VoidCallback? onInit,
-    @deprecated RendererCallback? onRendererHandler,
+    @Deprecated('Please, use the addOnInitListener method instead.')
+        VoidCallback? onInit,
+    @Deprecated('Please, use the addOnRendererEventListener method instead.')
+        RendererCallback? onRendererHandler,
   })  : _dataSourceType = DataSourceType.asset,
         _onInit = onInit,
         _onRendererHandler = onRendererHandler,
@@ -53,8 +55,10 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     this.hwAcc = HwAcc.AUTO,
     this.autoPlay = true,
     this.options,
-    @deprecated VoidCallback? onInit,
-    @deprecated RendererCallback? onRendererHandler,
+    @Deprecated('Please, use the addOnInitListener method instead.')
+        VoidCallback? onInit,
+    @Deprecated('Please, use the addOnRendererEventListener method instead.')
+        RendererCallback? onRendererHandler,
   })  : package = null,
         _dataSourceType = DataSourceType.network,
         _onInit = onInit,
@@ -71,8 +75,10 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     this.hwAcc = HwAcc.AUTO,
     this.autoPlay = true,
     this.options,
-    @deprecated VoidCallback? onInit,
-    @deprecated RendererCallback? onRendererHandler,
+    @Deprecated('Please, use the addOnInitListener method instead.')
+        VoidCallback? onInit,
+    @Deprecated('Please, use the addOnRendererEventListener method instead.')
+        RendererCallback? onRendererHandler,
   })  : dataSource = 'file://${file.path}',
         package = null,
         _dataSourceType = DataSourceType.file,
@@ -97,15 +103,17 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// Initialize vlc player when the platform is ready automatically
   final bool autoInitialize;
 
-  /// This parameter is deprecated, please, use the [addOnInitListener] method instead.
   /// This is a callback that will be executed once the platform view has been initialized.
   /// If you want the media to play as soon as the platform view has initialized, you could just call
-  /// [VlcPlayerController.play] in this callback. (see the example)
+  /// [VlcPlayerController.play] in this callback. (see the example).
+  ///
+  /// This member is deprecated, please, use the [addOnInitListener] method instead.
   final VoidCallback? _onInit;
 
-  /// This parameter is deprecated, please, use the [addOnRendererEventListener] method instead.
   /// This is a callback that will be executed every time a new renderer cast device attached/detached
   /// It should be defined as "void Function(VlcRendererEventType, String, String)", where the VlcRendererEventType is an enum { attached, detached } and the next two String arguments are unique-id and name of renderer device, respectively.
+  ///
+  /// This member is deprecated, please, use the [addOnRendererEventListener] method instead.
   final RendererCallback? _onRendererHandler;
 
   /// Only set for [asset] videos. The package that the asset was loaded from.

--- a/flutter_vlc_player/lib/src/vlc_player_controller.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_controller.dart
@@ -162,7 +162,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
             isBuffering: true,
             isEnded: false,
             playingState: PlayingState.buffering,
-            errorDescription: VlcPlayerValue.emptyString,
+            errorDescription: VlcPlayerValue.noError,
           );
           break;
 
@@ -196,7 +196,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
             activeAudioTrack: event.activeAudioTrack,
             spuTracksCount: event.spuTracksCount,
             activeSpuTrack: event.activeSpuTrack,
-            errorDescription: VlcPlayerValue.emptyString,
+            errorDescription: VlcPlayerValue.noError,
           );
           break;
 
@@ -228,7 +228,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
             playingState: (event.isPlaying ?? false)
                 ? PlayingState.playing
                 : value.playingState,
-            errorDescription: VlcPlayerValue.emptyString,
+            errorDescription: VlcPlayerValue.noError,
           );
           break;
 
@@ -241,7 +241,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
             isBuffering: false,
             isEnded: false,
             playingState: PlayingState.error,
-            errorDescription: 'VLC encountered an error!',
+            errorDescription: VlcPlayerValue.unknownError,
           );
           break;
 

--- a/flutter_vlc_player/lib/src/vlc_player_controller.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_controller.dart
@@ -35,8 +35,8 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     this.hwAcc = HwAcc.AUTO,
     this.autoPlay = true,
     this.options,
-    VoidCallback? onInit,
-    RendererCallback? onRendererHandler,
+    @deprecated VoidCallback? onInit,
+    @deprecated RendererCallback? onRendererHandler,
   })  : _dataSourceType = DataSourceType.asset,
         _onInit = onInit,
         _onRendererHandler = onRendererHandler,
@@ -53,8 +53,8 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     this.hwAcc = HwAcc.AUTO,
     this.autoPlay = true,
     this.options,
-    VoidCallback? onInit,
-    RendererCallback? onRendererHandler,
+    @deprecated VoidCallback? onInit,
+    @deprecated RendererCallback? onRendererHandler,
   })  : package = null,
         _dataSourceType = DataSourceType.network,
         _onInit = onInit,
@@ -71,8 +71,8 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     this.hwAcc = HwAcc.AUTO,
     this.autoPlay = true,
     this.options,
-    VoidCallback? onInit,
-    RendererCallback? onRendererHandler,
+    @deprecated VoidCallback? onInit,
+    @deprecated RendererCallback? onRendererHandler,
   })  : dataSource = 'file://${file.path}',
         package = null,
         _dataSourceType = DataSourceType.file,
@@ -97,11 +97,13 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// Initialize vlc player when the platform is ready automatically
   final bool autoInitialize;
 
+  /// This parameter is deprecated, please, use the [addOnInitListener] method instead.
   /// This is a callback that will be executed once the platform view has been initialized.
   /// If you want the media to play as soon as the platform view has initialized, you could just call
   /// [VlcPlayerController.play] in this callback. (see the example)
   final VoidCallback? _onInit;
 
+  /// This parameter is deprecated, please, use the [addOnRendererEventListener] method instead.
   /// This is a callback that will be executed every time a new renderer cast device attached/detached
   /// It should be defined as "void Function(VlcRendererEventType, String, String)", where the VlcRendererEventType is an enum { attached, detached } and the next two String arguments are unique-id and name of renderer device, respectively.
   final RendererCallback? _onRendererHandler;
@@ -129,32 +131,32 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// List of onInit listeners
   final List<VoidCallback> _onInitListeners = [];
 
-  /// add a listener to be notified on controller initialization
-  void addOnInitListener(VoidCallback listener) {
-    _onInitListeners.add(listener);
-  }
-
-  /// remove an onInit attached listener
-  void removeOnInitListener(VoidCallback listener) {
-    _onInitListeners.remove(listener);
-  }
-
   /// List of onRenderer listeners
-  final List<RendererCallback> _onRendererListeners = [];
-
-  /// add a listener to be notified when a cast renderer device gets attached/detached
-  void addOnRendererListener(RendererCallback listener) {
-    _onRendererListeners.add(listener);
-  }
-
-  /// remove a renderer attached listener
-  void removeOnRendererListener(RendererCallback listener) {
-    _onRendererListeners.remove(listener);
-  }
+  final List<RendererCallback> _onRendererEventListeners = [];
 
   bool _isDisposed = false;
 
   VlcAppLifeCycleObserver? _lifeCycleObserver;
+
+  /// Register a [VoidCallback] closure to be called when the controller gets initialized
+  void addOnInitListener(VoidCallback listener) {
+    _onInitListeners.add(listener);
+  }
+
+  /// Remove a previously registered closure from the list of onInit closures
+  void removeOnInitListener(VoidCallback listener) {
+    _onInitListeners.remove(listener);
+  }
+
+  /// Register a [RendererCallback] closure to be called when a cast renderer device gets attached/detached
+  void addOnRendererEventListener(RendererCallback listener) {
+    _onRendererEventListeners.add(listener);
+  }
+
+  /// Remove a previously registered closure from the list of OnRendererEvent closures
+  void removeOnRendererEventListener(RendererCallback listener) {
+    _onRendererEventListeners.remove(listener);
+  }
 
   /// Attempts to open the given [url] and load metadata about the video.
   Future<void> initialize() async {
@@ -335,15 +337,16 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     if (_isDisposed) {
       return;
     }
+    _onInitListeners.clear();
+    _onRendererEventListeners.clear();
     _lifeCycleObserver?.dispose();
     _isDisposed = true;
     super.dispose();
     //
-
     await vlcPlayerPlatform.dispose(_viewId);
   }
 
-  /// notify onInit callback & all registered listeners
+  /// Notify onInit callback & all registered listeners
   void _notifyOnInitListeners() {
     if (_onInit != null) {
       _onInit!();
@@ -351,7 +354,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     _onInitListeners.forEach((listener) => listener());
   }
 
-  /// notify onRendererHandler callback & all registered listeners
+  /// Notify onRendererHandler callback & all registered listeners
   void _notifyOnRendererListeners(
     VlcRendererEventType type,
     String? id,
@@ -360,7 +363,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
     if (_onRendererHandler != null) {
       _onRendererHandler!(type, id!, name!);
     }
-    _onRendererListeners.forEach((listener) => listener(type, id!, name!));
+    _onRendererEventListeners.forEach((listener) => listener(type, id!, name!));
   }
 
   /// This stops playback and changes the data source. Once the new data source has been loaded, the playback state will revert to

--- a/flutter_vlc_player/lib/src/vlc_player_value.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_value.dart
@@ -7,6 +7,9 @@ import 'enums/playing_state.dart';
 /// The duration, current position, buffering state, error state and settings
 /// of a [VlcPlayerController].
 class VlcPlayerValue {
+  /// Define Empty String
+  static const String emptyString = '';
+
   /// Constructs a video with the given values. Only [duration] is required. The
   /// rest will initialize with default values when unset.
   VlcPlayerValue({
@@ -31,7 +34,7 @@ class VlcPlayerValue {
     this.spuDelay = 0,
     this.videoTracksCount = 1,
     this.activeVideoTrack = 0,
-    this.errorDescription,
+    this.errorDescription = VlcPlayerValue.emptyString,
   });
 
   /// Returns an instance with a `null` [Duration].
@@ -49,7 +52,7 @@ class VlcPlayerValue {
       duration: Duration.zero,
       playingState: PlayingState.error,
       isInitialized: false,
-      errorDescription: errorDescription,
+      errorDescription: errorDescription ?? VlcPlayerValue.emptyString,
     );
   }
 
@@ -114,8 +117,8 @@ class VlcPlayerValue {
 
   /// A description of the error if present.
   ///
-  /// If [hasError] is false this is [null].
-  final String? errorDescription;
+  /// If [hasError] is false this is [empty].
+  final String errorDescription;
 
   /// The [size] of the currently loaded video.
   ///
@@ -127,7 +130,7 @@ class VlcPlayerValue {
 
   /// Indicates whether or not the video is in an error state. If this is true
   /// [errorDescription] should have information about the problem.
-  bool get hasError => errorDescription != null;
+  bool get hasError => errorDescription.isNotEmpty;
 
   /// Returns [size.width] / [size.height] when the player is initialized, or `1.0.` when
   /// the player is not initialized or the aspect ratio would be less than or equal to 0.0.

--- a/flutter_vlc_player/lib/src/vlc_player_value.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_value.dart
@@ -118,7 +118,7 @@ class VlcPlayerValue {
 
   /// A description of the error if present.
   ///
-  /// If [hasError] is false this is [empty].
+  /// If [hasError] is false this is [VlcPlayerValue.noError].
   final String errorDescription;
 
   /// The [size] of the currently loaded video.

--- a/flutter_vlc_player/lib/src/vlc_player_value.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_value.dart
@@ -7,8 +7,9 @@ import 'enums/playing_state.dart';
 /// The duration, current position, buffering state, error state and settings
 /// of a [VlcPlayerController].
 class VlcPlayerValue {
-  /// Define Empty String
-  static const String emptyString = '';
+  /// Define no error string
+  static const String noError = '';
+  static const String unknownError = 'An Unknown Error Occurred!';
 
   /// Constructs a video with the given values. Only [duration] is required. The
   /// rest will initialize with default values when unset.
@@ -34,7 +35,7 @@ class VlcPlayerValue {
     this.spuDelay = 0,
     this.videoTracksCount = 1,
     this.activeVideoTrack = 0,
-    this.errorDescription = VlcPlayerValue.emptyString,
+    this.errorDescription = VlcPlayerValue.noError,
   });
 
   /// Returns an instance with a `null` [Duration].
@@ -52,7 +53,7 @@ class VlcPlayerValue {
       duration: Duration.zero,
       playingState: PlayingState.error,
       isInitialized: false,
-      errorDescription: errorDescription ?? VlcPlayerValue.emptyString,
+      errorDescription: errorDescription ?? VlcPlayerValue.unknownError,
     );
   }
 

--- a/flutter_vlc_player/lib/src/vlc_player_value.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_value.dart
@@ -131,7 +131,7 @@ class VlcPlayerValue {
 
   /// Indicates whether or not the video is in an error state. If this is true
   /// [errorDescription] should have information about the problem.
-  bool get hasError => errorDescription.isNotEmpty;
+  bool get hasError => errorDescription != VlcPlayerValue.noError;
 
   /// Returns [size.width] / [size.height] when the player is initialized, or `1.0.` when
   /// the player is not initialized or the aspect ratio would be less than or equal to 0.0.

--- a/flutter_vlc_player/pubspec.yaml
+++ b/flutter_vlc_player/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
     sdk: flutter
   pigeon: 
     git:
-      url: https://github.com/Goddchen/packages.git
+      url: https://github.com/gaaclarke/packages.git
       path: packages/pigeon
-      ref: pigeon-null-safety
+      ref: pigeon-2-0-0
   plugin_platform_interface: ^2.0.0

--- a/flutter_vlc_player/pubspec.yaml
+++ b/flutter_vlc_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_vlc_player
 description: A VLC-powered alternative to Flutter's video_player. Supports multiple players on one screen.
-version: 6.0.1
+version: 6.0.2
 homepage: https://github.com/solid-software/flutter_vlc_player/
 
 environment:


### PR DESCRIPTION
Here is the list of changes:
- updated pigeon dependency
- added the missing getAvailableRendererServices() method
- make onInit & onRendererHandler callbacks to be public. by this change, you can register to these callbacks outside of default vlc controller constructors.
- fix vlc error event
