### PR TITLE
Remove the artificial delay during initialization

### DIFF
--- a/flutter_vlc_player/lib/src/vlc_player_controller.dart
+++ b/flutter_vlc_player/lib/src/vlc_player_controller.dart
@@ -935,9 +935,7 @@ class VlcPlayerController extends ValueNotifier<VlcPlayerValue> {
   /// This method will be called after the platform view has been created
   Future<void> onPlatformViewCreated(int viewId) async {
     _viewId = viewId;
-    // do we need to initialize controller after view becomes ready?
     if (autoInitialize) {
-      await Future.delayed(Duration(seconds: 1));
       await initialize();
     }
     _isReadyToInitialize = true;


### PR DESCRIPTION
Tested on:
- Android emulator;
- Android physical devices (Xiaomi with Android 7 and Huawei with Android 10);
- iOS Simulator (XCode 13.2).

No issues observed while testing -- not sure what the delay was for. Maybe it was a problem with an earlier Flutter version?

Needs testing on a physical iOS device.