### PR TITLE
Add Hybrid composition support for Android

### DIFF
--- a/flutter_vlc_player/android/build.gradle
+++ b/flutter_vlc_player/android/build.gradle
@@ -25,7 +25,7 @@ android {
     compileSdkVersion 31
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 20
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'org.videolan.android:libvlc-all:3.5.0-eap4'
+    implementation 'org.videolan.android:libvlc-all:3.5.0-eap6'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.annotation:annotation:1.2.0'

--- a/flutter_vlc_player/lib/src/flutter_vlc_player.dart
+++ b/flutter_vlc_player/lib/src/flutter_vlc_player.dart
@@ -7,6 +7,7 @@ class VlcPlayer extends StatefulWidget {
   final VlcPlayerController controller;
   final double aspectRatio;
   final Widget? placeholder;
+  final bool virtualDisplay;
 
   const VlcPlayer({
     Key? key,
@@ -23,6 +24,10 @@ class VlcPlayer extends StatefulWidget {
     /// Before the platform view has initialized, this placeholder will be rendered instead of the video player.
     /// This can simply be a [CircularProgressIndicator] (see the example.)
     this.placeholder,
+
+    /// Specify whether Virtual displays or Hybrid composition is used on Android.
+    /// iOS only uses Hybrid composition.
+    this.virtualDisplay = true
   }) : super(key: key);
 
   @override
@@ -90,7 +95,7 @@ class _VlcPlayerState extends State<VlcPlayer>
           Offstage(
             offstage: !_isInitialized,
             child: vlcPlayerPlatform
-                .buildView(widget.controller.onPlatformViewCreated),
+                .buildView(widget.controller.onPlatformViewCreated, virtualDisplay: widget.virtualDisplay),
           ),
         ],
       ),

--- a/flutter_vlc_player/pubspec.yaml
+++ b/flutter_vlc_player/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
  
   meta: ^1.7.0
-  flutter_vlc_player_platform_interface: ^2.0.0
+  flutter_vlc_player_platform_interface: ^2.0.1
 
 dev_dependencies:
   flutter_test:

--- a/flutter_vlc_player_platform_interface/lib/src/platform_interface/vlc_player_platform_interface.dart
+++ b/flutter_vlc_player_platform_interface/lib/src/platform_interface/vlc_player_platform_interface.dart
@@ -33,7 +33,7 @@ abstract class VlcPlayerPlatform extends PlatformInterface {
   }
 
   /// Returns a widget displaying the video.
-  Widget buildView(PlatformViewCreatedCallback onPlatformViewCreated) {
+  Widget buildView(PlatformViewCreatedCallback onPlatformViewCreated, {bool virtualDisplay = true}) {
     throw _unimplemented('buildView');
   }
 

--- a/flutter_vlc_player_platform_interface/pubspec.yaml
+++ b/flutter_vlc_player_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_vlc_player_platform_interface
 description: A common platform interface for the flutter vlc player plugin.
 homepage: https://github.com/solid-software/flutter_vlc_player
-version: 2.0.0
+version: 2.0.1
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
* minSdkVersion from 17 -> 20 as required by Virtual display.
* Bump ibvlc-all:3.5.0-eap4 -> libvlc-all:3.5.0-eap6
* Add `bool virtualDisplay` to specify whether Virtual displays or Hybrid composition is used on Android. Default is Virtual displays.
* Bump version of flutter_vlc_player_platform_interface: 2.0.0 -> 2.0.1
* Refers:  [platform-views](https://docs.flutter.dev/development/platform-integration/platform-views?tab=android-platform-views-kotlin-tab)