### PR TITLE
removed AutomaticKeepAliveClientMixin to fix/prevent unwanted behavior

### DIFF
--- a/flutter_vlc_player/CHANGELOG.md
+++ b/flutter_vlc_player/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.0.0
+* **Possible breaking Change**: Removed [AutomaticKeepAliveClientMixin](https://api.flutter.dev/flutter/widgets/AutomaticKeepAliveClientMixin-mixin.html) from plugin widget
+
 ## 7.2.0
 * Update to latest VLCKit sdks
 Credits to Mitch Ross (https://github.com/mitchross)

--- a/flutter_vlc_player/CHANGELOG.md
+++ b/flutter_vlc_player/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.0.0
+## 7.4.0
 * **Possible breaking Change**: Removed [AutomaticKeepAliveClientMixin](https://api.flutter.dev/flutter/widgets/AutomaticKeepAliveClientMixin-mixin.html) from plugin widget
 
 ## 7.3.1

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
@@ -70,6 +70,7 @@ final class FlutterVlcPlayer implements PlatformView {
         rendererEventChannel.setStreamHandler(null);
         if (mediaPlayer != null) {
             mediaPlayer.stop();
+            mediaPlayer.setEventListener(null);
             mediaPlayer.getVLCVout().detachViews();
             mediaPlayer.release();
             mediaPlayer = null;
@@ -125,7 +126,7 @@ final class FlutterVlcPlayer implements PlatformView {
     // }
 
     public void initialize(List<String> options) {
-        this.options = options; 
+        this.options = options;
         libVLC = new LibVLC(context, options);
         mediaPlayer = new MediaPlayer(libVLC);
         setupVlcMediaPlayer();
@@ -242,19 +243,19 @@ final class FlutterVlcPlayer implements PlatformView {
     }
 
     void play() {
-        if (mediaPlayer != null) {
+        if (mediaPlayer != null && !mediaPlayer.isPlaying()) {
             mediaPlayer.play();
         }
     }
 
     void pause() {
-        if (mediaPlayer != null) {
+        if (mediaPlayer != null && mediaPlayer.isPlaying()) {
             mediaPlayer.pause();
         }
     }
 
     void stop() {
-        if (mediaPlayer != null) {
+        if (mediaPlayer != null && mediaPlayer.isPlaying()) {
             mediaPlayer.stop();
         }
     }
@@ -273,7 +274,9 @@ final class FlutterVlcPlayer implements PlatformView {
         if (mediaPlayer == null) return;
 
         try {
-            mediaPlayer.stop();
+            if (mediaPlayer.isPlaying()) {
+                mediaPlayer.stop();
+            }
             //
             Media media;
             if (isAssetUrl)
@@ -295,15 +298,14 @@ final class FlutterVlcPlayer implements PlatformView {
                 media.addOption(":no-omxil-dr");
             }
             if (options != null) {
-                for (String option: options)
+                for (String option : options)
                     media.addOption(option);
             }
             mediaPlayer.setMedia(media);
             media.release();
             //
-            mediaPlayer.play();
-            if (!autoPlay) {
-                mediaPlayer.stop();
+            if (autoPlay) {
+                mediaPlayer.play();
             }
         } catch (IOException e) {
             log(e.getMessage());
@@ -350,7 +352,7 @@ final class FlutterVlcPlayer implements PlatformView {
 
     long getPosition() {
         if (mediaPlayer == null) return -1;
-        
+
         return mediaPlayer.getTime();
     }
 
@@ -612,8 +614,7 @@ final class FlutterVlcPlayer implements PlatformView {
         if (isDisposed) {
             return;
         }
-        boolean isPlaying = mediaPlayer.isPlaying();
-        if (isPlaying)
+        if (mediaPlayer.isPlaying())
             mediaPlayer.pause();
 
         // if you set it to null, it will start to render normally (i.e. locally) again

--- a/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
+++ b/flutter_vlc_player/android/src/main/java/software/solid/fluttervlcplayer/FlutterVlcPlayer.java
@@ -644,6 +644,7 @@ final class FlutterVlcPlayer implements PlatformView {
     }
 
     Boolean stopRecording() {
+        if (mediaPlayer == null) return true;
         return mediaPlayer.record(null);
     }
 

--- a/flutter_vlc_player/example/lib/multiple_tab.dart
+++ b/flutter_vlc_player/example/lib/multiple_tab.dart
@@ -45,6 +45,7 @@ class _MultipleTabState extends State<MultipleTab> {
     return Container(
       child: ListView.separated(
         itemCount: controllers.length,
+        cacheExtent: double.maxFinite,
         separatorBuilder: (_, index) {
           return Divider(height: 5, thickness: 5, color: Colors.grey);
         },

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -25,8 +25,7 @@ class VlcPlayerWithControls extends StatefulWidget {
   VlcPlayerWithControlsState createState() => VlcPlayerWithControlsState();
 }
 
-class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
-    with AutomaticKeepAliveClientMixin {
+class VlcPlayerWithControlsState extends State<VlcPlayerWithControls> {
   static const _playerControlsBgColor = Colors.black87;
 
   VlcPlayerController _controller;
@@ -52,9 +51,6 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
   //
   List<double> playbackSpeeds = [0.5, 1.0, 2.0];
   int playbackSpeedIndex = 1;
-
-  @override
-  bool get wantKeepAlive => true;
 
   @override
   void initState() {
@@ -116,7 +112,6 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -77,9 +77,9 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls> {
         final strDuration = oDuration.toString().split('.').first;
         setState(() {
           position =
-          "${strPosition.split(':')[1]}:${strPosition.split(':')[2]}";
+              "${strPosition.split(':')[1]}:${strPosition.split(':')[2]}";
           duration =
-          "${strDuration.split(':')[1]}:${strDuration.split(':')[2]}";
+              "${strDuration.split(':')[1]}:${strDuration.split(':')[2]}";
         });
       } else {
         setState(() {
@@ -259,11 +259,11 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls> {
                     children: [
                       Text(
                         'Size: ${_controller.value.size.width.toInt()}'
-                            'x${_controller.value.size.height.toInt()}',
+                        'x${_controller.value.size.height.toInt()}',
                         textAlign: TextAlign.center,
                         overflow: TextOverflow.ellipsis,
                         style:
-                        const TextStyle(color: Colors.white, fontSize: 10),
+                            const TextStyle(color: Colors.white, fontSize: 10),
                       ),
                       const SizedBox(height: 5),
                       Text(
@@ -271,7 +271,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls> {
                         textAlign: TextAlign.center,
                         overflow: TextOverflow.ellipsis,
                         style:
-                        const TextStyle(color: Colors.white, fontSize: 10),
+                            const TextStyle(color: Colors.white, fontSize: 10),
                       ),
                     ],
                   ),
@@ -291,7 +291,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls> {
                     controller: _controller,
                     aspectRatio: _aspectRatio,
                     placeholder:
-                    const Center(child: CircularProgressIndicator()),
+                        const Center(child: CircularProgressIndicator()),
                   ),
                 ),
                 Positioned(
@@ -350,7 +350,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls> {
                               ? 1.0
                               : _controller.value.duration.inSeconds.toDouble(),
                           onChanged:
-                          validPosition ? _onSliderPositionChanged : null,
+                              validPosition ? _onSliderPositionChanged : null,
                         ),
                       ),
                       Text(

--- a/flutter_vlc_player/ios/Classes/VlcViewController.swift
+++ b/flutter_vlc_player/ios/Classes/VlcViewController.swift
@@ -327,7 +327,11 @@ public class VLCViewController: NSObject, FlutterPlatformView {
     }
     
     public func dispose(){
-        //todo: dispose player & event handlers
+        self.mediaEventChannel.setStreamHandler(nil);
+        self.rendererEventChannel.setStreamHandler(nil);
+        self.rendererdiscoverers.removeAll()
+        self.rendererEventChannelHandler.renderItems.removeAll()
+        self.vlcMediaPlayer.stop()
     }
     
     func setMediaPlayerUrl(uri: String, isAssetUrl: Bool, autoPlay: Bool, hwAcc: Int, options: [String]){

--- a/flutter_vlc_player/lib/src/flutter_vlc_player.dart
+++ b/flutter_vlc_player/lib/src/flutter_vlc_player.dart
@@ -34,11 +34,7 @@ class VlcPlayer extends StatefulWidget {
   _VlcPlayerState createState() => _VlcPlayerState();
 }
 
-class _VlcPlayerState extends State<VlcPlayer>
-    with AutomaticKeepAliveClientMixin {
-  @override
-  bool get wantKeepAlive => true;
-
+class _VlcPlayerState extends State<VlcPlayer> {
   _VlcPlayerState() {
     _listener = () {
       if (!mounted) return;
@@ -83,7 +79,6 @@ class _VlcPlayerState extends State<VlcPlayer>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     return AspectRatio(
       aspectRatio: widget.aspectRatio,
       child: Stack(

--- a/flutter_vlc_player/pubspec.yaml
+++ b/flutter_vlc_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_vlc_player
 description: A VLC-powered alternative to Flutter's video_player. Supports multiple players on one screen.
-version: 8.0.0
+version: 7.4.0
 homepage: https://github.com/solid-software/flutter_vlc_player/
 
 environment:

--- a/flutter_vlc_player/pubspec.yaml
+++ b/flutter_vlc_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_vlc_player
 description: A VLC-powered alternative to Flutter's video_player. Supports multiple players on one screen.
-version: 7.2.0
+version: 8.0.0
 homepage: https://github.com/solid-software/flutter_vlc_player/
 
 environment:


### PR DESCRIPTION
AutomaticKeepAliveClientMixin was only to fix unwanted behavior of the example app.
This patch includes all necessary fixes for the example.
Maybe that is a breaking change for some projects but keeping alive should be handle on the plugin implementation side.