### PR TITLE
use `:http-user-agent` instead of `--http-user-agent`

### DIFF
--- a/flutter_vlc_player_platform_interface/lib/src/utils/options/vlc_http_options.dart
+++ b/flutter_vlc_player_platform_interface/lib/src/utils/options/vlc_http_options.dart
@@ -30,6 +30,8 @@ class VlcHttpOptions {
   /// HTTP server, i.e. the HTTP "User-Agent". Name and version must be
   /// separated by a forward slash, e.g. "FooBar/1.2.3".
   static String httpUserAgent(String userAgent) {
-    return '--http-user-agent=$userAgent';
+    // Use colon (:) instead of dashes.
+    // See https://stackoverflow.com/a/52127734/109747
+    return ':http-user-agent=$userAgent';
   }
 }


### PR DESCRIPTION
It took us about one day to figure out how to set http user agent since the double dash prefix didn't work.

See https://stackoverflow.com/a/52127734/109747