### PR TITLE
Fix github code-check

### DIFF
--- a/.github/workflows/code_check_for_flutter_vlc_player.yaml
+++ b/.github/workflows/code_check_for_flutter_vlc_player.yaml
@@ -30,7 +30,7 @@ jobs:
           dirs_to_analyze=""
           if [ -d lib ]; then dirs_to_analyze+=" lib"; fi
           if [ -d test ]; then dirs_to_analyze+=" test"; fi
-          if [ -d example ]; then dirs_to_analyze+=" example"; fi
+          if [ -d example/lib ]; then dirs_to_analyze+=" example/lib"; fi
           if [ dirs_to_analyze != "" ]
           then
             dart run dart_code_metrics:metrics \

--- a/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
+++ b/flutter_vlc_player/example/lib/vlc_player_with_controls.dart
@@ -310,7 +310,7 @@ class VlcPlayerWithControlsState extends State<VlcPlayerWithControls>
                       crossAxisAlignment: WrapCrossAlignment.center,
                       children: [
                         Icon(Icons.circle, color: Colors.red),
-                        SizedBox(width: 5),
+                        const SizedBox(width: 5),
                         Text(
                           'REC',
                           style: TextStyle(


### PR DESCRIPTION
Fixes failing `code-check`:

```
WARNING Avoid using magic numbers. Extract them to named constants or variables.
        at /home/runner/work/flutter_vlc_player/flutter_vlc_player/flutter_vlc_player/example/lib/vlc_player_with_controls.dart:313:41
```

https://github.com/solid-software/flutter_vlc_player/pull/435/checks