### PR TITLE
Update Gradle to 8.2 and AGP to 8.2.0

### DIFF
--- a/flutter_vlc_player/android/build.gradle
+++ b/flutter_vlc_player/android/build.gradle
@@ -22,6 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'software.solid.fluttervlcplayer'
+
     compileSdk 33
 
     defaultConfig {

--- a/flutter_vlc_player/android/src/main/AndroidManifest.xml
+++ b/flutter_vlc_player/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="software.solid.fluttervlcplayer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/flutter_vlc_player/example/android/app/build.gradle
+++ b/flutter_vlc_player/example/android/app/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'software.solid.fluttervlcplayerexample'
+
     compileSdkVersion 33
 
     lintOptions {

--- a/flutter_vlc_player/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_vlc_player/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="software.solid.fluttervlcplayerexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/flutter_vlc_player/example/android/build.gradle
+++ b/flutter_vlc_player/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
     }
 }
 

--- a/flutter_vlc_player/example/android/gradle.properties
+++ b/flutter_vlc_player/example/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8=true
+android.enableR8.fullMode=false

--- a/flutter_vlc_player/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_vlc_player/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip


### PR DESCRIPTION
Please accept this pull request and release a new version of the library since it's blocking compilation with Flutter 3.16.
Thank you!